### PR TITLE
Quick optimization pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ impl ServerMiddleware for FilterExpiredUsersMiddleware {
     async fn call(
         &self,
         chain: ChainIter,
-        job: Job,
+        job: &Job,
         worker: Box<dyn Worker>,
         redis: Pool<RedisConnectionManager>,
     ) -> ServerResult {

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -80,7 +80,7 @@ impl ServerMiddleware for FilterExpiredUsersMiddleware {
     async fn call(
         &self,
         chain: ChainIter,
-        job: Job,
+        job: &Job,
         worker: Box<dyn Worker>,
         redis: Pool<RedisConnectionManager>,
     ) -> ServerResult {
@@ -93,8 +93,8 @@ impl ServerMiddleware for FilterExpiredUsersMiddleware {
                 error!(
                     self.logger,
                     "Detected an expired user, skipping this job";
-                    "class" => job.class,
-                    "jid" => job.jid,
+                    "class" => &job.class,
+                    "jid" => &job.jid,
                     "user_guid" => filter.user_guid,
                 );
                 return Ok(());

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -42,8 +42,8 @@ impl ChainIter {
                         stack: self.stack.clone(),
                         index: self.index + 1,
                     },
-                    job.clone(),
-                    worker.clone(),
+                    job,
+                    worker,
                     redis,
                 )
                 .await?;

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -12,7 +12,7 @@ pub trait ServerMiddleware {
     async fn call(
         &self,
         iter: ChainIter,
-        job: Job,
+        job: &Job,
         worker: Box<dyn Worker>,
         redis: Pool<RedisConnectionManager>,
     ) -> ServerResult;
@@ -29,7 +29,7 @@ pub struct ChainIter {
 impl ChainIter {
     pub async fn next(
         &self,
-        job: Job,
+        job: &Job,
         worker: Box<dyn Worker>,
         redis: Pool<RedisConnectionManager>,
     ) -> ServerResult {
@@ -94,7 +94,7 @@ impl Chain {
 
     pub(crate) async fn call(
         &mut self,
-        job: Job,
+        job: &Job,
         worker: Box<dyn Worker>,
         redis: Pool<RedisConnectionManager>,
     ) -> ServerResult {
@@ -113,11 +113,11 @@ impl ServerMiddleware for HandlerMiddleware {
     async fn call(
         &self,
         _chain: ChainIter,
-        job: Job,
+        job: &Job,
         worker: Box<dyn Worker>,
         _redis: Pool<RedisConnectionManager>,
     ) -> ServerResult {
-        worker.perform(job.args).await
+        worker.perform(job.args.clone()).await
     }
 }
 
@@ -136,18 +136,20 @@ impl ServerMiddleware for RetryMiddleware {
     async fn call(
         &self,
         chain: ChainIter,
-        mut job: Job,
+        job: &Job,
         worker: Box<dyn Worker>,
         mut redis: Pool<RedisConnectionManager>,
     ) -> ServerResult {
         let max_retries = worker.max_retries();
 
         let err = {
-            match chain.next(job.clone(), worker, redis.clone()).await {
+            match chain.next(job, worker, redis.clone()).await {
                 Ok(()) => return Ok(()),
                 Err(err) => format!("{err:?}"),
             }
         };
+
+        let mut job = job.clone();
 
         // Update error fields on the job.
         job.error_message = Some(err);
@@ -170,9 +172,7 @@ impl ServerMiddleware for RetryMiddleware {
                 "err" => &job.error_message,
             );
 
-            UnitOfWork::from_job(job.clone())
-                .reenqueue(&mut redis)
-                .await?;
+            UnitOfWork::from_job(job).reenqueue(&mut redis).await?;
         }
 
         Ok(())

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -51,7 +51,7 @@ impl Processor {
 
         if let Some(worker) = self.workers.get_mut(&work.job.class) {
             self.chain
-                .call(work.job.clone(), worker.clone(), self.redis.clone())
+                .call(&work.job, worker.clone(), self.redis.clone())
                 .await?;
         } else {
             error!(


### PR DESCRIPTION
This removes unnecessary clone calls and makes `Job` a reference through the middleware interface. It might make sense to have `args: JsonValue` be a reference as well. The reason I'm not sure yet is that clone is required to call `serde_json::from_value` but not all jobs take arguments. 