### PR TITLE
WIP: Rewrite Worker to be generic over Args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,12 +127,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 
 [[package]]
-name = "dyn-clone"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e50f3adc76d6a43f5ed73b698a87d0760ca74617f60f7c3b879003536fdd28"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,7 +526,6 @@ dependencies = [
  "async-trait",
  "bb8-redis",
  "chrono",
- "dyn-clone",
  "heck",
  "hex",
  "num_cpus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ redis = { version = "0.21", features = ["aio", "default", "tokio-comp"] }
 async-trait = "0.1"
 slog = "2.7"
 slog-term = "2.9"
-dyn-clone = "1"
 bb8-redis = "0.10"
 num_cpus = "1.13"
 chrono = "0.4"

--- a/README.md
+++ b/README.md
@@ -48,11 +48,7 @@ impl Worker for PaymentReportWorker {
     }
 
     // Worker implementation
-    async fn perform(&self, args: JsonValue) -> Result<(), Box<dyn std::error::Error>> {
-        // I use serde to pull out my args as a type. I fail if the value cannot be decoded.
-        // NOTE: I use a size-one (tuple,) tuple because args are a JsonArray.
-        let (args,): (PaymentReportArgs,) = serde_json::from_value(args)?;
-
+    async fn perform(&self, args: PaymentReportArgs) -> Result<(), Box<dyn std::error::Error>> {
         self.send_report(args.user_guid).await
     }
 }
@@ -169,7 +165,7 @@ impl ServerMiddleware for FilterExpiredUsersMiddleware {
         &self,
         chain: ChainIter,
         job: &Job,
-        worker: Box<dyn Worker>,
+        worker: Arc<WorkerCaller>,
         redis: Pool<RedisConnectionManager>,
     ) -> ServerResult {
         // Use serde to check if a user_guid is part of the job args.

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ impl ServerMiddleware for FilterExpiredUsersMiddleware {
         &self,
         chain: ChainIter,
         job: &Job,
-        worker: Arc<WorkerCaller>,
+        worker: Arc<WorkerRef>,
         redis: Pool<RedisConnectionManager>,
     ) -> ServerResult {
         // Use serde to check if a user_guid is part of the job args.

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use bb8_redis::{bb8::Pool, RedisConnectionManager};
 use serde::{Deserialize, Serialize};
-use sidekiq::{ChainIter, Job, Processor, ServerMiddleware, ServerResult, Worker, WorkerCaller};
+use sidekiq::{ChainIter, Job, Processor, ServerMiddleware, ServerResult, Worker, WorkerRef};
 use slog::{error, info, o, Drain};
 use std::sync::Arc;
 
@@ -77,7 +77,7 @@ impl ServerMiddleware for FilterExpiredUsersMiddleware {
         &self,
         chain: ChainIter,
         job: &Job,
-        worker: Arc<WorkerCaller>,
+        worker: Arc<WorkerRef>,
         redis: Pool<RedisConnectionManager>,
     ) -> ServerResult {
         let args: Result<(FiltereExpiredUsersArgs,), serde_json::Error> =

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1,10 +1,7 @@
 use async_trait::async_trait;
 use bb8_redis::{bb8::Pool, RedisConnectionManager};
 use serde::{Deserialize, Serialize};
-use serde_json::Value as JsonValue;
-use sidekiq::{
-    ChainIter, Job, Processor, ServerMiddleware, ServerResult, WorkerCaller, WorkerGeneric,
-};
+use sidekiq::{ChainIter, Job, Processor, ServerMiddleware, ServerResult, Worker, WorkerCaller};
 use slog::{error, info, o, Drain};
 use std::sync::Arc;
 
@@ -12,7 +9,7 @@ use std::sync::Arc;
 struct HelloWorker;
 
 #[async_trait]
-impl WorkerGeneric<()> for HelloWorker {
+impl Worker<()> for HelloWorker {
     async fn perform(&self, _args: ()) -> Result<(), Box<dyn std::error::Error>> {
         // I don't use any args. I do my own work.
         Ok(())
@@ -43,7 +40,7 @@ struct PaymentReportArgs {
 }
 
 #[async_trait]
-impl WorkerGeneric<PaymentReportArgs> for PaymentReportWorker {
+impl Worker<PaymentReportArgs> for PaymentReportWorker {
     fn opts() -> sidekiq::WorkerOpts<PaymentReportArgs, Self> {
         sidekiq::WorkerOpts::new().queue("yolo")
     }

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -2,15 +2,18 @@ use async_trait::async_trait;
 use bb8_redis::{bb8::Pool, RedisConnectionManager};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
-use sidekiq::{ChainIter, Job, Processor, ServerMiddleware, ServerResult, Worker};
+use sidekiq::{
+    ChainIter, Job, Processor, ServerMiddleware, ServerResult, WorkerCaller, WorkerGeneric,
+};
 use slog::{error, info, o, Drain};
+use std::sync::Arc;
 
 #[derive(Clone)]
 struct HelloWorker;
 
 #[async_trait]
-impl Worker for HelloWorker {
-    async fn perform(&self, _args: JsonValue) -> Result<(), Box<dyn std::error::Error>> {
+impl WorkerGeneric<()> for HelloWorker {
+    async fn perform(&self, _args: ()) -> Result<(), Box<dyn std::error::Error>> {
         // I don't use any args. I do my own work.
         Ok(())
     }
@@ -40,16 +43,12 @@ struct PaymentReportArgs {
 }
 
 #[async_trait]
-impl Worker for PaymentReportWorker {
-    fn opts() -> sidekiq::WorkerOpts<Self> {
+impl WorkerGeneric<PaymentReportArgs> for PaymentReportWorker {
+    fn opts() -> sidekiq::WorkerOpts<PaymentReportArgs, Self> {
         sidekiq::WorkerOpts::new().queue("yolo")
     }
 
-    async fn perform(&self, args: JsonValue) -> Result<(), Box<dyn std::error::Error>> {
-        // I use serde to pull out my args as a type. I fail if the value cannot be decoded.
-        // NOTE: I use a size-one (tuple,) tuple because args are a JsonArray.
-        let (args,): (PaymentReportArgs,) = serde_json::from_value(args)?;
-
+    async fn perform(&self, args: PaymentReportArgs) -> Result<(), Box<dyn std::error::Error>> {
         self.send_report(args.user_guid).await
     }
 }
@@ -81,7 +80,7 @@ impl ServerMiddleware for FilterExpiredUsersMiddleware {
         &self,
         chain: ChainIter,
         job: &Job,
-        worker: Box<dyn Worker>,
+        worker: Arc<WorkerCaller>,
         redis: Pool<RedisConnectionManager>,
     ) -> ServerResult {
         let args: Result<(FiltereExpiredUsersArgs,), serde_json::Error> =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,7 +253,7 @@ pub trait Worker<Args>: Send + Sync {
 // we can wrap that generic work in a callback that shares the same type.
 // I'm sure this has a fancy name, but I don't know what it is.
 #[derive(Clone)]
-pub struct WorkerCaller {
+pub struct WorkerRef {
     work_fn: Arc<
         Box<
             dyn Fn(
@@ -292,7 +292,7 @@ where
     Ok(worker.perform(args).await?)
 }
 
-impl WorkerCaller {
+impl WorkerRef {
     pub(crate) fn wrap<Args, W>(worker: Arc<W>) -> Self
     where
         Args: Send + Sync + 'static,
@@ -457,7 +457,7 @@ mod test {
     #[tokio::test]
     async fn testing_some_basic_configuration() {
         let worker = Arc::new(TestGenericWorker);
-        let wrap = Arc::new(WorkerCaller::wrap(worker));
+        let wrap = Arc::new(WorkerRef::wrap(worker));
 
         for _ in 0..1 {
             let wrap = wrap.clone();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -436,7 +436,9 @@ impl UnitOfWork {
 }
 
 #[cfg(test)]
-mod testing {
+mod test {
+    use super::*;
+
     #[derive(Deserialize, Serialize)]
     struct TestArg {
         name: String,
@@ -447,7 +449,7 @@ mod testing {
 
     #[async_trait]
     impl Worker<TestArg> for TestGenericWorker {
-        async fn perform(&self, args: TestArg) -> ServerResult {
+        async fn perform(&self, _args: TestArg) -> ServerResult {
             Ok(())
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,11 +224,11 @@ pub trait Worker<Args>: Send + Sync {
 
     async fn perform_async(
         redis: &mut Pool<RedisConnectionManager>,
-        args: impl serde::Serialize + Send + 'static,
+        args: Args,
     ) -> Result<(), Box<dyn std::error::Error>>
     where
         Self: Sized,
-        Args: Send + Sync,
+        Args: Send + Sync + serde::Serialize + 'static,
     {
         Self::opts().perform_async(redis, args).await
     }
@@ -236,11 +236,11 @@ pub trait Worker<Args>: Send + Sync {
     async fn perform_in(
         redis: &mut Pool<RedisConnectionManager>,
         duration: std::time::Duration,
-        args: impl serde::Serialize + Send + 'static,
+        args: Args,
     ) -> Result<(), Box<dyn std::error::Error>>
     where
         Self: Sized,
-        Args: Send + Sync,
+        Args: Send + Sync + serde::Serialize + 'static,
     {
         Self::opts().perform_in(redis, duration, args).await
     }
@@ -305,9 +305,6 @@ impl WorkerCaller {
                 move |args: JsonValue| {
                     let worker = worker.clone();
                     Box::pin(async move { Ok(call_worker(args, worker).await?) })
-                    //let args: Args = serde_json::from_value(args).unwrap();
-
-                    //Box::pin(async move { Ok(worker.perform(args).await?) })
                 }
             })),
             max_retries: worker.max_retries(),

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,4 +1,4 @@
-use crate::{Job, UnitOfWork, WorkerCaller, WorkerGeneric};
+use crate::{Job, UnitOfWork, WorkerCaller};
 use async_trait::async_trait;
 use bb8_redis::{bb8::Pool, RedisConnectionManager};
 use slog::error;
@@ -212,7 +212,7 @@ mod test {
     }
 
     #[async_trait]
-    impl WorkerGeneric<()> for TestWorker {
+    impl Worker<()> for TestWorker {
         async fn perform(&self, _args: ()) -> Result<(), Box<dyn std::error::Error>> {
             *self.touched.lock().await = true;
             Ok(())

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -182,7 +182,7 @@ impl ServerMiddleware for RetryMiddleware {
 #[cfg(test)]
 mod test {
     use super::*;
-    use serde_json::Value as JsonValue;
+    use crate::Worker;
     use tokio::sync::Mutex;
 
     async fn redis() -> Pool<RedisConnectionManager> {

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,4 +1,4 @@
-use crate::{Job, UnitOfWork, Worker};
+use crate::{Job, UnitOfWork, WorkerCaller};
 use async_trait::async_trait;
 use bb8_redis::{bb8::Pool, RedisConnectionManager};
 use slog::error;
@@ -13,7 +13,7 @@ pub trait ServerMiddleware {
         &self,
         iter: ChainIter,
         job: &Job,
-        worker: Box<dyn Worker>,
+        worker: Arc<WorkerCaller>,
         redis: Pool<RedisConnectionManager>,
     ) -> ServerResult;
 }
@@ -30,7 +30,7 @@ impl ChainIter {
     pub async fn next(
         &self,
         job: &Job,
-        worker: Box<dyn Worker>,
+        worker: Arc<WorkerCaller>,
         redis: Pool<RedisConnectionManager>,
     ) -> ServerResult {
         let stack = self.stack.read().await;
@@ -95,7 +95,7 @@ impl Chain {
     pub(crate) async fn call(
         &mut self,
         job: &Job,
-        worker: Box<dyn Worker>,
+        worker: Arc<WorkerCaller>,
         redis: Pool<RedisConnectionManager>,
     ) -> ServerResult {
         // The middleware must call bottom of the stack to the top.
@@ -114,10 +114,10 @@ impl ServerMiddleware for HandlerMiddleware {
         &self,
         _chain: ChainIter,
         job: &Job,
-        worker: Box<dyn Worker>,
+        worker: Arc<WorkerCaller>,
         _redis: Pool<RedisConnectionManager>,
     ) -> ServerResult {
-        worker.perform(job.args.clone()).await
+        worker.call(job.args.clone()).await
     }
 }
 
@@ -137,7 +137,7 @@ impl ServerMiddleware for RetryMiddleware {
         &self,
         chain: ChainIter,
         job: &Job,
-        worker: Box<dyn Worker>,
+        worker: Arc<WorkerCaller>,
         mut redis: Pool<RedisConnectionManager>,
     ) -> ServerResult {
         let max_retries = worker.max_retries();
@@ -212,8 +212,8 @@ mod test {
     }
 
     #[async_trait]
-    impl Worker for TestWorker {
-        async fn perform(&self, _args: JsonValue) -> Result<(), Box<dyn std::error::Error>> {
+    impl WorkerGeneric<()> for TestWorker {
+        async fn perform(&self, _args: ()) -> Result<(), Box<dyn std::error::Error>> {
             *self.touched.lock().await = true;
             Ok(())
         }
@@ -225,10 +225,11 @@ mod test {
             touched: Arc::new(Mutex::new(false)),
         });
 
+        let job = job();
         let mut chain = Chain::empty();
         chain.using(Box::new(HandlerMiddleware)).await;
         chain
-            .call(job(), worker.clone(), redis().await)
+            .call(&job, worker.clone(), redis().await)
             .await
             .unwrap();
 

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -1,4 +1,4 @@
-use crate::{Chain, Job, Scheduled, ServerMiddleware, UnitOfWork, WorkerCaller, WorkerGeneric};
+use crate::{Chain, Job, Scheduled, ServerMiddleware, UnitOfWork, Worker, WorkerCaller};
 use bb8_redis::{bb8::Pool, redis::AsyncCommands, RedisConnectionManager};
 use slog::{error, info};
 use std::collections::BTreeMap;
@@ -81,7 +81,7 @@ impl Processor {
 
     pub fn register<
         Args: Sync + Send + for<'de> serde::Deserialize<'de> + 'static,
-        W: WorkerGeneric<Args> + 'static,
+        W: Worker<Args> + 'static,
     >(
         &mut self,
         worker: W,

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -1,4 +1,4 @@
-use crate::{Chain, Job, Scheduled, ServerMiddleware, UnitOfWork, Worker, WorkerCaller};
+use crate::{Chain, Job, Scheduled, ServerMiddleware, UnitOfWork, Worker, WorkerRef};
 use bb8_redis::{bb8::Pool, redis::AsyncCommands, RedisConnectionManager};
 use slog::{error, info};
 use std::collections::BTreeMap;
@@ -8,7 +8,7 @@ use std::sync::Arc;
 pub struct Processor {
     redis: Pool<RedisConnectionManager>,
     queues: Vec<String>,
-    workers: BTreeMap<String, Arc<WorkerCaller>>,
+    workers: BTreeMap<String, Arc<WorkerRef>>,
     logger: slog::Logger,
     chain: Chain,
 }
@@ -86,10 +86,8 @@ impl Processor {
         &mut self,
         worker: W,
     ) {
-        self.workers.insert(
-            W::class_name(),
-            Arc::new(WorkerCaller::wrap(Arc::new(worker))),
-        );
+        self.workers
+            .insert(W::class_name(), Arc::new(WorkerRef::wrap(Arc::new(worker))));
     }
 
     /// Takes self to consume the processor. This is for life-cycle management, not


### PR DESCRIPTION
This is a pretty major change to the lib, but since nobody is likely using it, I think we're ok.

I was hoping to make this lib use generic arguments at the start but couldn't find a way to make it work. The biggest thing I ran into was that I can't create a `Box<dyn Worker<T>>` without specifying `T` which made it impossible to build a data structure that could hold any variety of `Worker` and `T`.  However, through several interesting blog posts and stack overflow comments I realized I could hide the `T` by wrapping the invocation of the worker with a closure. In other words, because the input and output are the same for any `Box<dyn Worker<T>>`, the `T` could be encapsulated inside of a closure. To make things easier I created a `WorkerRef` type that holds the `Fn` trait impl and some metadata about the underlying worker. From there I added several layers of `Arc`s to remove the dyn clone dependency and I think we ended in an OK spot.

One non-standard thing this PR depends on is around deserializing the `()` type. If you have any valid json value but you want to create a worker that ignores those args, you'll likely get a deserialization error since `()` doesn't cleanly deserialize from some value. To work around this I guarantee `()` will always decode by using `td::any::TypeId::of::<Args>()`. Not the best, but it works.

Finally, by default, to make deserialization convenient, I check for a `JsonValue::Array` that might be a single element and pluck that element out before deserializing to `Args`. This is because sidekiq stores args in an array, even if there's only one parameter. In the ruby world, this looks like `worker.perform(*args)`, but this doesn't translate well to rust. This part needs a little more work so that `Vec<T>` or `(T,)` workers can be built with this worker. 