### PR TITLE
Support redis namespaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,17 +44,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bb8-redis"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c440295545cb69b3cec992ae8844fbb1de1c84f2f90248438af287e14bb09bde"
-dependencies = [
- "async-trait",
- "bb8",
- "redis",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -548,10 +537,10 @@ checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
 
 [[package]]
 name = "rusty-sidekiq"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
- "bb8-redis",
+ "bb8",
  "chrono",
  "cron_clock",
  "heck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ redis = { version = "0.21", features = ["aio", "default", "tokio-comp"] }
 async-trait = "0.1"
 slog = "2.7"
 slog-term = "2.9"
-bb8-redis = "0.10"
+bb8 = "0.7"
 num_cpus = "1.13"
 chrono = "0.4"
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty-sidekiq"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "A rust sidekiq server and client using tokio"
 authors = ["Garrett Thornburg <garrett.thornburg@hey.com>"]
@@ -14,7 +14,7 @@ readme = "README.md"
 name = "sidekiq"
 
 [dependencies]
-tokio = { version = "1", features = ["full"]} 
+tokio = { version = "1", features = ["full"]}
 serde_json = { version = "1" }
 serde = { version = "1.0", features = ["derive"] }
 redis = { version = "0.21", features = ["aio", "default", "tokio-comp"] }

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1,9 +1,10 @@
 use async_trait::async_trait;
-use bb8_redis::{bb8::Pool, RedisConnectionManager};
+use bb8::Pool;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sidekiq::{
-    periodic, ChainIter, Job, Processor, ServerMiddleware, ServerResult, Worker, WorkerRef,
+    periodic, ChainIter, Job, Processor, RedisConnectionManager, RedisPool, ServerMiddleware,
+    ServerResult, Worker, WorkerRef,
 };
 use slog::{error, info, o, Drain};
 use std::sync::Arc;
@@ -81,7 +82,7 @@ impl ServerMiddleware for FilterExpiredUsersMiddleware {
         chain: ChainIter,
         job: &Job,
         worker: Arc<WorkerRef>,
-        redis: Pool<RedisConnectionManager>,
+        redis: RedisPool,
     ) -> ServerResult {
         let args: Result<(FiltereExpiredUsersArgs,), serde_json::Error> =
             serde_json::from_value(job.args.clone());

--- a/examples/namespaced_demo.rs
+++ b/examples/namespaced_demo.rs
@@ -1,0 +1,53 @@
+use async_trait::async_trait;
+use bb8::Pool;
+use sidekiq::{Processor, RedisConnectionManager, Worker};
+use slog::{o, Drain};
+
+#[derive(Clone)]
+struct HelloWorker;
+
+#[async_trait]
+impl Worker<()> for HelloWorker {
+    async fn perform(&self, _args: ()) -> Result<(), Box<dyn std::error::Error>> {
+        println!("Hello, world!");
+
+        Ok(())
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Logger
+    let decorator = slog_term::PlainSyncDecorator::new(std::io::stdout());
+    let drain = slog_term::FullFormat::new(decorator).build().fuse();
+    let logger = slog::Logger::root(drain, o!());
+
+    // Redis
+    let manager = RedisConnectionManager::new("redis://127.0.0.1/")?;
+    let redis = Pool::builder()
+        .connection_customizer(sidekiq::with_custom_namespace("cool_app".to_string()))
+        .build(manager)
+        .await?;
+
+    tokio::spawn({
+        let mut redis = redis.clone();
+
+        async move {
+            loop {
+                HelloWorker::perform_async(&mut redis, ()).await.unwrap();
+
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            }
+        }
+    });
+
+    // Sidekiq server
+    let mut p = Processor::new(redis.clone(), logger.clone(), vec!["default".to_string()]);
+
+    // Add known workers
+    p.register(HelloWorker);
+
+    // Start!
+    p.run().await;
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,9 @@ mod redis;
 mod scheduled;
 
 // Re-export
-pub use crate::redis::{RedisConnection, RedisConnectionManager, RedisPool};
+pub use crate::redis::{
+    with_custom_namespace, RedisConnection, RedisConnectionManager, RedisError, RedisPool,
+};
 pub use middleware::{ChainIter, ServerMiddleware, ServerResult};
 pub use processor::{Processor, WorkFetcher};
 pub use scheduled::Scheduled;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 use async_trait::async_trait;
-use bb8_redis::{bb8::Pool, redis::AsyncCommands, RedisConnectionManager};
 use middleware::Chain;
 use rand::{Rng, RngCore};
 use serde::{Deserialize, Serialize};
@@ -13,9 +12,11 @@ pub mod periodic;
 
 mod middleware;
 mod processor;
+mod redis;
 mod scheduled;
 
 // Re-export
+pub use crate::redis::{RedisConnection, RedisConnectionManager, RedisPool};
 pub use middleware::{ChainIter, ServerMiddleware, ServerResult};
 pub use processor::{Processor, WorkFetcher};
 pub use scheduled::Scheduled;
@@ -77,7 +78,7 @@ impl EnqueueOpts {
 
     pub async fn perform_async(
         self,
-        redis: &mut Pool<RedisConnectionManager>,
+        redis: &mut RedisPool,
         class: String,
         args: impl serde::Serialize,
     ) -> Result<(), Box<dyn std::error::Error>> {
@@ -88,7 +89,7 @@ impl EnqueueOpts {
 
     pub async fn perform_in(
         &self,
-        redis: &mut Pool<RedisConnectionManager>,
+        redis: &mut RedisPool,
         class: String,
         duration: std::time::Duration,
         args: impl serde::Serialize,
@@ -102,7 +103,7 @@ impl EnqueueOpts {
 /// Helper function for enqueueing a worker into sidekiq.
 /// This can be used to enqueue a job for a ruby sidekiq worker to process.
 pub async fn perform_async(
-    redis: &mut Pool<RedisConnectionManager>,
+    redis: &mut RedisPool,
     class: String,
     queue: String,
     args: impl serde::Serialize,
@@ -113,7 +114,7 @@ pub async fn perform_async(
 /// Helper function for enqueueing a worker into sidekiq.
 /// This can be used to enqueue a job for a ruby sidekiq worker to process.
 pub async fn perform_in(
-    redis: &mut Pool<RedisConnectionManager>,
+    redis: &mut RedisPool,
     duration: std::time::Duration,
     class: String,
     queue: String,
@@ -168,7 +169,7 @@ where
 
     pub async fn perform_async(
         &self,
-        redis: &mut Pool<RedisConnectionManager>,
+        redis: &mut RedisPool,
         args: impl serde::Serialize + Send + 'static,
     ) -> Result<(), Box<dyn std::error::Error>> {
         self.into_opts()
@@ -178,7 +179,7 @@ where
 
     pub async fn perform_in(
         &self,
-        redis: &mut Pool<RedisConnectionManager>,
+        redis: &mut RedisPool,
         duration: std::time::Duration,
         args: impl serde::Serialize + Send + 'static,
     ) -> Result<(), Box<dyn std::error::Error>> {
@@ -233,7 +234,7 @@ pub trait Worker<Args>: Send + Sync {
     }
 
     async fn perform_async(
-        redis: &mut Pool<RedisConnectionManager>,
+        redis: &mut RedisPool,
         args: Args,
     ) -> Result<(), Box<dyn std::error::Error>>
     where
@@ -244,7 +245,7 @@ pub trait Worker<Args>: Send + Sync {
     }
 
     async fn perform_in(
-        redis: &mut Pool<RedisConnectionManager>,
+        redis: &mut RedisPool,
         duration: std::time::Duration,
         args: Args,
     ) -> Result<(), Box<dyn std::error::Error>>
@@ -383,37 +384,34 @@ impl UnitOfWork {
         Ok(Self::from_job(job))
     }
 
-    pub async fn enqueue(
-        &self,
-        redis: &mut Pool<RedisConnectionManager>,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn enqueue(&self, redis: &mut RedisPool) -> Result<(), Box<dyn std::error::Error>> {
         let mut redis = redis.get().await?;
-        self.enqueue_direct(&mut redis).await
+        self.enqueue_direct(&mut *redis).await
     }
 
     async fn enqueue_direct(
         &self,
-        redis: &mut redis::aio::Connection,
+        redis: &mut RedisConnection,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let mut job = self.job.clone();
         job.enqueued_at = Some(chrono::Utc::now().timestamp() as f64);
 
         redis
-            .rpush(&self.queue, serde_json::to_string(&job)?)
+            .rpush(self.queue.clone(), serde_json::to_string(&job)?)
             .await?;
         Ok(())
     }
 
     pub async fn reenqueue(
         &mut self,
-        redis: &mut Pool<RedisConnectionManager>,
+        redis: &mut RedisPool,
     ) -> Result<(), Box<dyn std::error::Error>> {
         if let Some(retry_count) = self.job.retry_count {
             redis
                 .get()
                 .await?
                 .zadd(
-                    "retry",
+                    "retry".to_string(),
                     serde_json::to_string(&self.job)?,
                     Self::retry_job_at(retry_count).timestamp(),
                 )
@@ -432,20 +430,22 @@ impl UnitOfWork {
 
     pub async fn schedule(
         &mut self,
-        redis: &mut Pool<RedisConnectionManager>,
+        redis: &mut RedisPool,
         duration: std::time::Duration,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let enqueue_at = chrono::Utc::now() + chrono::Duration::from_std(duration)?;
 
-        Ok(redis
+        redis
             .get()
             .await?
             .zadd(
-                "schedule",
+                "schedule".to_string(),
                 serde_json::to_string(&self.job)?,
                 enqueue_at.timestamp(),
             )
-            .await?)
+            .await?;
+
+        Ok(())
     }
 }
 

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -181,7 +181,8 @@ impl ServerMiddleware for RetryMiddleware {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::Worker;
+    use crate::{RedisConnectionManager, RedisPool, Worker};
+    use bb8::Pool;
     use tokio::sync::Mutex;
 
     async fn redis() -> RedisPool {

--- a/src/periodic.rs
+++ b/src/periodic.rs
@@ -167,13 +167,13 @@ impl PeriodicJob {
             // when we submit it to redis. We can use this to determine if we were the lucky
             // process that changed the periodic job to its next scheduled time and enqueue
             // the job.
-            return Ok(redis::cmd("ZADD")
-                .arg("periodic")
-                .arg("CH")
-                .arg(next_scheduled_time)
-                .arg(periodic_job_str)
-                .query_async(conn.borrow_mut())
-                .await?);
+            return conn
+                .zadd_ch(
+                    "periodic".to_string(),
+                    periodic_job_str,
+                    next_scheduled_time,
+                )
+                .await;
         }
 
         Err(format!(

--- a/src/redis.rs
+++ b/src/redis.rs
@@ -1,0 +1,212 @@
+use bb8::{ManageConnection, Pool, PooledConnection};
+
+use async_trait::async_trait;
+use redis::AsyncCommands;
+use redis::ToRedisArgs;
+use redis::{aio::Connection, ErrorKind};
+use redis::{Client, IntoConnectionInfo, RedisError};
+use std::ops::DerefMut;
+
+pub type RedisPool = Pool<RedisConnectionManager>;
+
+/// A `bb8::ManageConnection` for `redis::Client::get_async_connection` wrapped in a helper type
+/// for namespacing.
+#[derive(Clone, Debug)]
+pub struct RedisConnectionManager {
+    client: Client,
+}
+
+impl RedisConnectionManager {
+    /// Create a new `RedisConnectionManager`.
+    /// See `redis::Client::open` for a description of the parameter types.
+    pub fn new<T: IntoConnectionInfo>(info: T) -> Result<Self, RedisError> {
+        Ok(RedisConnectionManager {
+            client: Client::open(info.into_connection_info()?)?,
+        })
+    }
+}
+
+#[async_trait]
+impl ManageConnection for RedisConnectionManager {
+    type Connection = RedisConnection;
+    type Error = RedisError;
+
+    async fn connect(&self) -> Result<Self::Connection, Self::Error> {
+        Ok(RedisConnection::new(
+            self.client.get_async_connection().await?,
+        ))
+    }
+
+    async fn is_valid(&self, conn: &mut PooledConnection<'_, Self>) -> Result<(), Self::Error> {
+        let pong: String = redis::cmd("PING")
+            .query_async(&mut conn.deref_mut().connection)
+            .await?;
+        match pong.as_str() {
+            "PONG" => Ok(()),
+            _ => Err((ErrorKind::ResponseError, "ping request").into()),
+        }
+    }
+
+    fn has_broken(&self, _: &mut Self::Connection) -> bool {
+        false
+    }
+}
+
+/// A wrapper type for making the redis crate compatible with namespacing.
+pub struct RedisConnection {
+    connection: Connection,
+    namespace: Option<String>,
+}
+
+impl RedisConnection {
+    pub fn new(connection: Connection) -> Self {
+        Self {
+            connection,
+            namespace: None,
+        }
+    }
+
+    pub fn with_namespace(self, namespace: String) -> Self {
+        Self {
+            connection: self.connection,
+            namespace: Some(namespace),
+        }
+    }
+
+    fn namespaced_key(&self, key: String) -> String {
+        if let Some(ref namespace) = self.namespace {
+            return format!("{namespace}:{key}");
+        }
+
+        key
+    }
+
+    fn namespaced_keys(&self, keys: Vec<String>) -> Vec<String> {
+        if let Some(ref namespace) = self.namespace {
+            let keys: Vec<String> = keys
+                .iter()
+                .map(|key| format!("{namespace}:{key}"))
+                .collect();
+
+            return keys;
+        }
+
+        keys
+    }
+
+    pub fn borrow_mut(&mut self) -> &mut Connection {
+        &mut self.connection
+    }
+
+    pub async fn del(&mut self, key: String) -> Result<usize, Box<dyn std::error::Error>> {
+        Ok(self.connection.del(self.namespaced_key(key)).await?)
+    }
+
+    pub async fn brpop(
+        &mut self,
+        keys: Vec<String>,
+        timeout: usize,
+    ) -> Result<Option<(String, String)>, Box<dyn std::error::Error>> {
+        Ok(self
+            .connection
+            .brpop(self.namespaced_keys(keys), timeout)
+            .await?)
+    }
+    //    pub async fn brpop_direct(
+    //        &self,
+    //        conn: &mut RedisConnection,
+    //        keys: Vec<String>,
+    //        timeout: usize,
+    //    ) -> Result<Option<(String, String)>, Box<dyn std::error::Error>> {
+    //        Ok(conn.brpop(self.namespaced_keys(keys), timeout).await?)
+    //    }
+
+    pub async fn zadd<V: ToRedisArgs + Send + Sync, S: ToRedisArgs + Send + Sync>(
+        &mut self,
+        key: String,
+        value: V,
+        score: S,
+    ) -> Result<usize, Box<dyn std::error::Error>> {
+        Ok(self
+            .connection
+            .zadd(self.namespaced_key(key), value, score)
+            .await?)
+    }
+    //    pub async fn zadd_direct(
+    //        &self,
+    //        conn: &mut RedisConnection,
+    //        key: String,
+    //        value: String,
+    //        score: f64,
+    //    ) -> Result<usize, Box<dyn std::error::Error>> {
+    //        Ok(conn.zadd(self.namespaced_key(key), value, score).await?)
+    //    }
+
+    pub async fn rpush(
+        &mut self,
+        key: String,
+        value: String,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        Ok(self
+            .connection
+            .rpush(self.namespaced_key(key), value)
+            .await?)
+    }
+    //    pub async fn rpush_direct(
+    //        &self,
+    //        conn: &mut RedisConnection,
+    //        key: String,
+    //        value: String,
+    //    ) -> Result<(), Box<dyn std::error::Error>> {
+    //        conn.rpush(self.namespaced_key(key), value).await?;
+    //
+    //        Ok(())
+    //    }
+
+    pub async fn zrangebyscore_limit<L: ToRedisArgs + Send + Sync, U: ToRedisArgs + Sync + Send>(
+        &mut self,
+        key: String,
+        lower: L,
+        upper: U,
+        offset: isize,
+        limit: isize,
+    ) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+        Ok(self
+            .connection
+            .zrangebyscore_limit(self.namespaced_key(key), lower, upper, offset, limit)
+            .await?)
+    }
+    //    pub async fn zrangebyscore_limit_direct(
+    //        &self,
+    //        conn: &mut RedisConnection,
+    //        keys: Vec<String>,
+    //        lower: &str,
+    //        upper: &str,
+    //        offset: isize,
+    //        limit: isize,
+    //    ) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    //        Ok(conn
+    //            .zrangebyscore_limit(self.namespaced_keys(keys), lower, upper, offset, limit)
+    //            .await?)
+    //    }
+
+    pub async fn zrem(
+        &mut self,
+        key: String,
+        value: String,
+    ) -> Result<bool, Box<dyn std::error::Error>> {
+        Ok(self
+            .connection
+            .zrem(self.namespaced_key(key), value)
+            .await?)
+    }
+    //    pub async fn zrem_direct(
+    //        &self,
+    //        conn: &mut RedisConnection,
+    //        key: String,
+    //        value: String,
+    //    ) -> Result<(), Box<dyn std::error::Error>> {
+    //        conn.zrem(self.namespaced_key(key), value).await?;
+    //        Ok(())
+    //    }
+}

--- a/src/redis.rs
+++ b/src/redis.rs
@@ -150,6 +150,18 @@ impl RedisConnection {
             .await?)
     }
 
+    pub async fn zrange(
+        &mut self,
+        key: String,
+        lower: isize,
+        upper: isize,
+    ) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+        Ok(self
+            .connection
+            .zrange(self.namespaced_key(key), lower, upper)
+            .await?)
+    }
+
     pub async fn zrangebyscore_limit<L: ToRedisArgs + Send + Sync, U: ToRedisArgs + Sync + Send>(
         &mut self,
         key: String,

--- a/tests/process_async_test.rs
+++ b/tests/process_async_test.rs
@@ -1,8 +1,8 @@
 #[cfg(test)]
 mod test {
     use async_trait::async_trait;
-    use bb8_redis::{bb8::Pool, RedisConnectionManager};
-    use sidekiq::{Processor, WorkFetcher, Worker};
+    use bb8::Pool;
+    use sidekiq::{Processor, RedisConnectionManager, RedisPool, WorkFetcher, Worker};
     use slog::{o, Drain};
     use std::sync::{Arc, Mutex};
 
@@ -16,15 +16,13 @@ mod test {
         async fn flushall(&self) {
             let mut conn = self.get().await.unwrap();
             let _: String = redis::cmd("FLUSHALL")
-                .query_async(&mut *conn)
+                .query_async(conn.unnamespaced_borrow_mut())
                 .await
                 .unwrap();
         }
     }
 
-    async fn new_base_processor(
-        queue: String,
-    ) -> (Processor, RedisPool, slog::Logger) {
+    async fn new_base_processor(queue: String) -> (Processor, RedisPool, slog::Logger) {
         // Logger
         let decorator = slog_term::PlainSyncDecorator::new(std::io::stdout());
         let drain = slog_term::FullFormat::new(decorator).build().fuse();

--- a/tests/process_async_test.rs
+++ b/tests/process_async_test.rs
@@ -12,7 +12,7 @@ mod test {
     }
 
     #[async_trait]
-    impl FlushAll for Pool<RedisConnectionManager> {
+    impl FlushAll for RedisPool {
         async fn flushall(&self) {
             let mut conn = self.get().await.unwrap();
             let _: String = redis::cmd("FLUSHALL")
@@ -24,7 +24,7 @@ mod test {
 
     async fn new_base_processor(
         queue: String,
-    ) -> (Processor, Pool<RedisConnectionManager>, slog::Logger) {
+    ) -> (Processor, RedisPool, slog::Logger) {
         // Logger
         let decorator = slog_term::PlainSyncDecorator::new(std::io::stdout());
         let drain = slog_term::FullFormat::new(decorator).build().fuse();

--- a/tests/process_cron_job_test.rs
+++ b/tests/process_cron_job_test.rs
@@ -12,7 +12,7 @@ mod test {
     }
 
     #[async_trait]
-    impl FlushAll for Pool<RedisConnectionManager> {
+    impl FlushAll for RedisPool {
         async fn flushall(&self) {
             let mut conn = self.get().await.unwrap();
             let _: String = redis::cmd("FLUSHALL")
@@ -24,7 +24,7 @@ mod test {
 
     async fn new_base_processor(
         queue: String,
-    ) -> (Processor, Pool<RedisConnectionManager>, slog::Logger) {
+    ) -> (Processor, RedisPool, slog::Logger) {
         // Logger
         let decorator = slog_term::PlainSyncDecorator::new(std::io::stdout());
         let drain = slog_term::FullFormat::new(decorator).build().fuse();
@@ -41,7 +41,7 @@ mod test {
         (p, redis, logger)
     }
 
-    async fn set_cron_scores_to_zero(redis: Pool<RedisConnectionManager>) {
+    async fn set_cron_scores_to_zero(redis: RedisPool) {
         let mut conn = redis.get().await.unwrap();
 
         let jobs: Vec<String> = redis::cmd("ZRANGE")

--- a/tests/process_cron_job_test.rs
+++ b/tests/process_cron_job_test.rs
@@ -1,8 +1,10 @@
 #[cfg(test)]
 mod test {
     use async_trait::async_trait;
-    use bb8_redis::{bb8::Pool, redis::AsyncCommands, RedisConnectionManager};
-    use sidekiq::{periodic, Processor, Scheduled, WorkFetcher, Worker};
+    use bb8::Pool;
+    use sidekiq::{
+        periodic, Processor, RedisConnectionManager, RedisPool, Scheduled, WorkFetcher, Worker,
+    };
     use slog::{o, Drain};
     use std::sync::{Arc, Mutex};
 
@@ -16,15 +18,13 @@ mod test {
         async fn flushall(&self) {
             let mut conn = self.get().await.unwrap();
             let _: String = redis::cmd("FLUSHALL")
-                .query_async(&mut *conn)
+                .query_async(conn.unnamespaced_borrow_mut())
                 .await
                 .unwrap();
         }
     }
 
-    async fn new_base_processor(
-        queue: String,
-    ) -> (Processor, RedisPool, slog::Logger) {
+    async fn new_base_processor(queue: String) -> (Processor, RedisPool, slog::Logger) {
         // Logger
         let decorator = slog_term::PlainSyncDecorator::new(std::io::stdout());
         let drain = slog_term::FullFormat::new(decorator).build().fuse();
@@ -44,16 +44,16 @@ mod test {
     async fn set_cron_scores_to_zero(redis: RedisPool) {
         let mut conn = redis.get().await.unwrap();
 
-        let jobs: Vec<String> = redis::cmd("ZRANGE")
-            .arg("periodic")
-            .arg(i32::MIN)
-            .arg(i32::MAX)
-            .query_async(&mut *conn)
+        let jobs = conn
+            .zrange("periodic".to_string(), isize::MIN, isize::MAX)
             .await
             .unwrap();
 
         for job in jobs {
-            let _: usize = conn.zadd("periodic", job.clone(), 0).await.unwrap();
+            let _: usize = conn
+                .zadd("periodic".to_string(), job.clone(), 0)
+                .await
+                .unwrap();
         }
     }
 

--- a/tests/process_scheduled_job_test.rs
+++ b/tests/process_scheduled_job_test.rs
@@ -12,7 +12,7 @@ mod test {
     }
 
     #[async_trait]
-    impl FlushAll for Pool<RedisConnectionManager> {
+    impl FlushAll for RedisPool {
         async fn flushall(&self) {
             let mut conn = self.get().await.unwrap();
             let _: String = redis::cmd("FLUSHALL")
@@ -24,7 +24,7 @@ mod test {
 
     async fn new_base_processor(
         queue: String,
-    ) -> (Processor, Pool<RedisConnectionManager>, slog::Logger) {
+    ) -> (Processor, RedisPool, slog::Logger) {
         // Logger
         let decorator = slog_term::PlainSyncDecorator::new(std::io::stdout());
         let drain = slog_term::FullFormat::new(decorator).build().fuse();


### PR DESCRIPTION
Impl https://github.com/film42/sidekiq-rs/issues/7

This adds a shim around the redis connection to support namespaces similar to the https://github.com/resque/redis-namespace gem. This allows cooperation with ruby apps that depend on this feature.

There may be a slight uptick in allocations because I can't be as clever about passing by reference since we're going to mutate all keys for each redis call but that's something we may be able to optimize later.

The test suite is passing once again and I added an example showing how to activate the namespace mode.

Going to let this sit for a day and come back to review.

@justmark Would you mind trying to run your project against this PR?

To use namespace:

```rust
    // Redis
    let manager = RedisConnectionManager::new("redis://127.0.0.1/")?;
    let redis = Pool::builder()
        .connection_customizer(sidekiq::with_custom_namespace("cool_app".to_string())) // Do this!
        .build(manager)
        .await?;
```

## NOTE: This does introduce a breaking change. We switch from `Pool<RedisManagedConnection>` to the `sidekiq::RedisPool` type and drop the `bb8_redis` dep. Instead, we implement our own redis pool.