### PR TITLE
Fix bug: We should use lpush not rpush

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty-sidekiq"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "A rust sidekiq server and client using tokio"
 authors = ["Garrett Thornburg <garrett.thornburg@hey.com>"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -399,7 +399,7 @@ impl UnitOfWork {
         job.enqueued_at = Some(chrono::Utc::now().timestamp() as f64);
 
         redis
-            .rpush(self.queue.clone(), serde_json::to_string(&job)?)
+            .lpush(self.queue.clone(), serde_json::to_string(&job)?)
             .await?;
         Ok(())
     }

--- a/src/redis.rs
+++ b/src/redis.rs
@@ -139,14 +139,14 @@ impl RedisConnection {
         Ok(self.connection.del(self.namespaced_key(key)).await?)
     }
 
-    pub async fn rpush(
+    pub async fn lpush(
         &mut self,
         key: String,
         value: String,
     ) -> Result<(), Box<dyn std::error::Error>> {
         Ok(self
             .connection
-            .rpush(self.namespaced_key(key), value)
+            .lpush(self.namespaced_key(key), value)
             .await?)
     }
 


### PR DESCRIPTION
Pretty simple change but an important one. LIFO vs FIFO queue.