### PR TITLE
Add queue to "queues" at enqueue time for stats

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -398,6 +398,8 @@ impl UnitOfWork {
         let mut job = self.job.clone();
         job.enqueued_at = Some(chrono::Utc::now().timestamp() as f64);
 
+        redis.sadd("queues".to_string(), job.queue.clone()).await?;
+
         redis
             .lpush(self.queue.clone(), serde_json::to_string(&job)?)
             .await?;

--- a/src/redis.rs
+++ b/src/redis.rs
@@ -150,6 +150,17 @@ impl RedisConnection {
             .await?)
     }
 
+    pub async fn sadd(
+        &mut self,
+        key: String,
+        value: String,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        Ok(self
+            .connection
+            .sadd(self.namespaced_key(key), value)
+            .await?)
+    }
+
     pub async fn zrange(
         &mut self,
         key: String,


### PR DESCRIPTION
This will make queues show up and have their counts visible in sidekiq-web.

The server side is a much larger piece that requires a heartbeat and some process metrics. Still figuring out how to make that work in a clean way. This change is probably more important at the moment.