### PR TITLE
Proof of concept custom unique hash override

### DIFF
--- a/examples/unique.rs
+++ b/examples/unique.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use bb8::Pool;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use sidekiq::{Processor, RedisConnectionManager, Worker};
 use slog::{o, Drain};
 
@@ -24,6 +25,30 @@ impl Worker<CustomerNotification> for CustomerNotificationWorker {
 #[derive(Deserialize, Debug, Serialize)]
 struct CustomerNotification {
     customer_guid: String,
+    date_string: String,
+}
+
+#[derive(Clone)]
+struct CustomerSuperUniqueNotificationWorker;
+
+#[async_trait]
+impl Worker<CustomerNotification> for CustomerSuperUniqueNotificationWorker {
+    fn opts() -> sidekiq::WorkerOpts<CustomerNotification, Self> {
+        // Use default options to set the unique_for option by default.
+        sidekiq::WorkerOpts::new()
+            .queue("customers")
+            .unique_for(std::time::Duration::from_secs(30))
+    }
+
+    fn unique_hash_for_args(
+        args: &CustomerNotification,
+    ) -> Result<String, Box<dyn std::error::Error>> {
+        Ok(format!("{:x}", Sha256::digest(&args.customer_guid)))
+    }
+
+    async fn perform(&self, _args: CustomerNotification) -> Result<(), Box<dyn std::error::Error>> {
+        Ok(())
+    }
 }
 
 #[tokio::main]
@@ -42,17 +67,32 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Add known workers
     p.register(CustomerNotificationWorker);
+    p.register(CustomerSuperUniqueNotificationWorker);
 
     // Create a bunch of jobs with the default uniqueness options. Only
     // one of these should be created within a 30 second period.
-    for _ in 1..10 {
-        CustomerNotificationWorker::perform_async(
-            &mut redis,
-            CustomerNotification {
-                customer_guid: "CST-123".to_string(),
-            },
-        )
-        .await?;
+    for n in 1..10 {
+        for _ in 1..10 {
+            let date_string = format!("{n}/{n}/2022");
+
+            CustomerNotificationWorker::perform_async(
+                &mut redis,
+                CustomerNotification {
+                    customer_guid: "CST-123".to_string(),
+                    date_string: date_string.clone(),
+                },
+            )
+            .await?;
+
+            CustomerSuperUniqueNotificationWorker::perform_async(
+                &mut redis,
+                CustomerNotification {
+                    customer_guid: "CST-123".to_string(),
+                    date_string: date_string.clone(),
+                },
+            )
+            .await?;
+        }
     }
 
     // Override the unique_for option. Note: Because the code above
@@ -64,6 +104,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             &mut redis,
             CustomerNotification {
                 customer_guid: "CST-123".to_string(),
+                date_string: "01-01-1970".to_string(),
             },
         )
         .await?;

--- a/examples/unique.rs
+++ b/examples/unique.rs
@@ -92,6 +92,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 },
             )
             .await?;
+
+            sidekiq::opts()
+                .queue("other-app")
+                .unique_for(std::time::Duration::from_secs(60))
+                .unique_hash_for_args("CUSTOMER-123".to_string())
+                .perform_async(
+                    &mut redis,
+                    "SomeUniqueWorkerThatLivesSomewhereElse".to_string(),
+                    CustomerNotification {
+                        customer_guid: "CST-123".to_string(),
+                        date_string: date_string.clone(),
+                    },
+                )
+                .await?;
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,7 +195,7 @@ where
     where
         Args: serde::Serialize,
     {
-        W::unique_hash_for_args(&args)
+        W::unique_hash_for_args(args)
     }
 
     pub fn unique_for(self, unique_for: std::time::Duration) -> Self {

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -232,6 +232,7 @@ mod test {
             retry_count: None,
             retried_at: None,
             unique_for: None,
+            unique_hash_for_args: None,
         }
     }
 

--- a/src/periodic.rs
+++ b/src/periodic.rs
@@ -214,6 +214,7 @@ impl PeriodicJob {
 
             // Meta data not used in periodic jobs right now...
             unique_for: None,
+            unique_hash_for_args: None,
         }
     }
 }


### PR DESCRIPTION
This allows you to implement a custom unique hash function on the worker trait, so that when a job is enqueued with the `unique_for(duration)` option, a custom hash will be used instead of the generic `sha256(to_json(args))` implementation.

It's a little clunky at this point, but I wanted to open a proof of concept PR to give time to think about how this should be implemented.

NOTE: While `unique_for` will work just fine without a worker trait being implemented (for workers implemented in other projects or other languages), this current implementation of `uniq_hash_for_args` is only defined on the worker trait. Otherwise, you'll need to specify a custom unique hash as you enqueue the worker. Example:

```rust
            sidekiq::opts()
                .queue("other-app")
                .unique_for(std::time::Duration::from_secs(60))
                .unique_hash_for_args("CUSTOMER-123".to_string())
                .perform_async(
                    &mut redis,
                    "SomeUniqueWorkerThatLivesSomewhereElse".to_string(),
                    CustomerNotification {
                        customer_guid: "CST-123".to_string(),
                        date_string: date_string.clone(),
                    },
                )
                .await?;
```

It's nice that this will still work, but it's a little clunky.

Otherwise the impl looks like:

```rust
#[derive(Clone)]
struct CustomerSuperUniqueNotificationWorker;

#[async_trait]
impl Worker<CustomerNotification> for CustomerSuperUniqueNotificationWorker {
    fn opts() -> sidekiq::WorkerOpts<CustomerNotification, Self> {
        // Use default options to set the unique_for option by default.
        sidekiq::WorkerOpts::new()
            .queue("customers")
            .unique_for(std::time::Duration::from_secs(30))
    }

    fn unique_hash_for_args(
        args: &CustomerNotification,
    ) -> Result<String, Box<dyn std::error::Error>> {
        Ok(format!("{:x}", Sha256::digest(&args.customer_guid)))
    }

    async fn perform(&self, _args: CustomerNotification) -> Result<(), Box<dyn std::error::Error>> {
        Ok(())
    }
}
```

Naming isn't superb but it's functional.