### PR TITLE
Refactor redis wrapper to use RedisError type instead of generic Box

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -423,7 +423,7 @@ impl UnitOfWork {
 
     pub async fn enqueue(&self, redis: &mut RedisPool) -> Result<(), Box<dyn std::error::Error>> {
         let mut redis = redis.get().await?;
-        self.enqueue_direct(&mut *redis).await
+        self.enqueue_direct(&mut redis).await
     }
 
     async fn enqueue_direct(

--- a/src/periodic.rs
+++ b/src/periodic.rs
@@ -167,13 +167,13 @@ impl PeriodicJob {
             // when we submit it to redis. We can use this to determine if we were the lucky
             // process that changed the periodic job to its next scheduled time and enqueue
             // the job.
-            return conn
+            return Ok(conn
                 .zadd_ch(
                     "periodic".to_string(),
                     periodic_job_str,
                     next_scheduled_time,
                 )
-                .await;
+                .await?);
         }
 
         Err(format!(

--- a/src/redis.rs
+++ b/src/redis.rs
@@ -69,8 +69,8 @@ impl ManageConnection for RedisConnectionManager {
         }
     }
 
-    fn has_broken(&self, _: &mut Self::Connection) -> bool {
-        false
+    fn has_broken(&self, conn: &mut Self::Connection) -> bool {
+        conn.has_broken()
     }
 }
 
@@ -78,6 +78,7 @@ impl ManageConnection for RedisConnectionManager {
 pub struct RedisConnection {
     connection: Connection,
     namespace: Option<String>,
+    has_broken: bool,
 }
 
 impl RedisConnection {
@@ -85,7 +86,12 @@ impl RedisConnection {
         Self {
             connection,
             namespace: None,
+            has_broken: false,
         }
+    }
+
+    pub fn has_broken(&self) -> bool {
+        self.has_broken
     }
 
     pub fn set_namespace(&mut self, namespace: String) {
@@ -96,7 +102,15 @@ impl RedisConnection {
         Self {
             connection: self.connection,
             namespace: Some(namespace),
+            has_broken: self.has_broken,
         }
+    }
+
+    fn check_connection(&mut self, err: RedisError) -> RedisError {
+        if err.is_io_error() {
+            self.has_broken = true;
+        }
+        err
     }
 
     fn namespaced_key(&self, key: String) -> String {
@@ -129,11 +143,12 @@ impl RedisConnection {
         &mut self,
         keys: Vec<String>,
         timeout: usize,
-    ) -> Result<Option<(String, String)>, Box<dyn std::error::Error>> {
+    ) -> Result<Option<(String, String)>, RedisError> {
         Ok(self
             .connection
             .brpop(self.namespaced_keys(keys), timeout)
-            .await?)
+            .await
+            .map_err(|err| self.check_connection(err))?)
     }
 
     pub fn cmd_with_key(&mut self, cmd: &str, key: String) -> redis::Cmd {
@@ -142,41 +157,36 @@ impl RedisConnection {
         c
     }
 
-    pub async fn del(&mut self, key: String) -> Result<usize, Box<dyn std::error::Error>> {
-        Ok(self.connection.del(self.namespaced_key(key)).await?)
+    pub async fn del(&mut self, key: String) -> Result<usize, RedisError> {
+        Ok(self
+            .connection
+            .del(self.namespaced_key(key))
+            .await
+            .map_err(|err| self.check_connection(err))?)
     }
 
-    pub async fn expire(
-        &mut self,
-        key: String,
-        value: usize,
-    ) -> Result<usize, Box<dyn std::error::Error>> {
+    pub async fn expire(&mut self, key: String, value: usize) -> Result<usize, RedisError> {
         Ok(self
             .connection
             .expire(self.namespaced_key(key), value)
-            .await?)
+            .await
+            .map_err(|err| self.check_connection(err))?)
     }
 
-    pub async fn lpush(
-        &mut self,
-        key: String,
-        value: String,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn lpush(&mut self, key: String, value: String) -> Result<(), RedisError> {
         Ok(self
             .connection
             .lpush(self.namespaced_key(key), value)
-            .await?)
+            .await
+            .map_err(|err| self.check_connection(err))?)
     }
 
-    pub async fn sadd(
-        &mut self,
-        key: String,
-        value: String,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn sadd(&mut self, key: String, value: String) -> Result<(), RedisError> {
         Ok(self
             .connection
             .sadd(self.namespaced_key(key), value)
-            .await?)
+            .await
+            .map_err(|err| self.check_connection(err))?)
     }
 
     pub async fn set_nx_ex(
@@ -184,7 +194,7 @@ impl RedisConnection {
         key: String,
         value: String,
         ttl_in_seconds: usize,
-    ) -> Result<RedisValue, Box<dyn std::error::Error>> {
+    ) -> Result<RedisValue, RedisError> {
         Ok(redis::cmd("SET")
             .arg(self.namespaced_key(key))
             .arg(value)
@@ -192,7 +202,8 @@ impl RedisConnection {
             .arg("EX")
             .arg(ttl_in_seconds)
             .query_async(self.unnamespaced_borrow_mut())
-            .await?)
+            .await
+            .map_err(|err| self.check_connection(err))?)
     }
 
     pub async fn zrange(
@@ -200,11 +211,12 @@ impl RedisConnection {
         key: String,
         lower: isize,
         upper: isize,
-    ) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    ) -> Result<Vec<String>, RedisError> {
         Ok(self
             .connection
             .zrange(self.namespaced_key(key), lower, upper)
-            .await?)
+            .await
+            .map_err(|err| self.check_connection(err))?)
     }
 
     pub async fn zrangebyscore_limit<L: ToRedisArgs + Send + Sync, U: ToRedisArgs + Sync + Send>(
@@ -214,11 +226,12 @@ impl RedisConnection {
         upper: U,
         offset: isize,
         limit: isize,
-    ) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    ) -> Result<Vec<String>, RedisError> {
         Ok(self
             .connection
             .zrangebyscore_limit(self.namespaced_key(key), lower, upper, offset, limit)
-            .await?)
+            .await
+            .map_err(|err| self.check_connection(err))?)
     }
 
     pub async fn zadd<V: ToRedisArgs + Send + Sync, S: ToRedisArgs + Send + Sync>(
@@ -226,11 +239,12 @@ impl RedisConnection {
         key: String,
         value: V,
         score: S,
-    ) -> Result<usize, Box<dyn std::error::Error>> {
+    ) -> Result<usize, RedisError> {
         Ok(self
             .connection
             .zadd(self.namespaced_key(key), value, score)
-            .await?)
+            .await
+            .map_err(|err| self.check_connection(err))?)
     }
 
     pub async fn zadd_ch<V: ToRedisArgs + Send + Sync, S: ToRedisArgs + Send + Sync>(
@@ -238,24 +252,22 @@ impl RedisConnection {
         key: String,
         value: V,
         score: S,
-    ) -> Result<bool, Box<dyn std::error::Error>> {
+    ) -> Result<bool, RedisError> {
         Ok(redis::cmd("ZADD")
             .arg(self.namespaced_key(key))
             .arg("CH")
             .arg(score)
             .arg(value)
             .query_async(self.unnamespaced_borrow_mut())
-            .await?)
+            .await
+            .map_err(|err| self.check_connection(err))?)
     }
 
-    pub async fn zrem(
-        &mut self,
-        key: String,
-        value: String,
-    ) -> Result<bool, Box<dyn std::error::Error>> {
+    pub async fn zrem(&mut self, key: String, value: String) -> Result<bool, RedisError> {
         Ok(self
             .connection
             .zrem(self.namespaced_key(key), value)
-            .await?)
+            .await
+            .map_err(|err| self.check_connection(err))?)
     }
 }

--- a/src/redis.rs
+++ b/src/redis.rs
@@ -144,11 +144,11 @@ impl RedisConnection {
         keys: Vec<String>,
         timeout: usize,
     ) -> Result<Option<(String, String)>, RedisError> {
-        Ok(self
+        self
             .connection
             .brpop(self.namespaced_keys(keys), timeout)
             .await
-            .map_err(|err| self.check_connection(err))?)
+            .map_err(|err| self.check_connection(err))
     }
 
     pub fn cmd_with_key(&mut self, cmd: &str, key: String) -> redis::Cmd {
@@ -158,35 +158,35 @@ impl RedisConnection {
     }
 
     pub async fn del(&mut self, key: String) -> Result<usize, RedisError> {
-        Ok(self
+        self
             .connection
             .del(self.namespaced_key(key))
             .await
-            .map_err(|err| self.check_connection(err))?)
+            .map_err(|err| self.check_connection(err))
     }
 
     pub async fn expire(&mut self, key: String, value: usize) -> Result<usize, RedisError> {
-        Ok(self
+        self
             .connection
             .expire(self.namespaced_key(key), value)
             .await
-            .map_err(|err| self.check_connection(err))?)
+            .map_err(|err| self.check_connection(err))
     }
 
     pub async fn lpush(&mut self, key: String, value: String) -> Result<(), RedisError> {
-        Ok(self
+        self
             .connection
             .lpush(self.namespaced_key(key), value)
             .await
-            .map_err(|err| self.check_connection(err))?)
+            .map_err(|err| self.check_connection(err))
     }
 
     pub async fn sadd(&mut self, key: String, value: String) -> Result<(), RedisError> {
-        Ok(self
+        self
             .connection
             .sadd(self.namespaced_key(key), value)
             .await
-            .map_err(|err| self.check_connection(err))?)
+            .map_err(|err| self.check_connection(err))
     }
 
     pub async fn set_nx_ex(
@@ -195,7 +195,7 @@ impl RedisConnection {
         value: String,
         ttl_in_seconds: usize,
     ) -> Result<RedisValue, RedisError> {
-        Ok(redis::cmd("SET")
+        redis::cmd("SET")
             .arg(self.namespaced_key(key))
             .arg(value)
             .arg("NX")
@@ -203,7 +203,7 @@ impl RedisConnection {
             .arg(ttl_in_seconds)
             .query_async(self.unnamespaced_borrow_mut())
             .await
-            .map_err(|err| self.check_connection(err))?)
+            .map_err(|err| self.check_connection(err))
     }
 
     pub async fn zrange(
@@ -212,11 +212,11 @@ impl RedisConnection {
         lower: isize,
         upper: isize,
     ) -> Result<Vec<String>, RedisError> {
-        Ok(self
+        self
             .connection
             .zrange(self.namespaced_key(key), lower, upper)
             .await
-            .map_err(|err| self.check_connection(err))?)
+            .map_err(|err| self.check_connection(err))
     }
 
     pub async fn zrangebyscore_limit<L: ToRedisArgs + Send + Sync, U: ToRedisArgs + Sync + Send>(
@@ -227,11 +227,11 @@ impl RedisConnection {
         offset: isize,
         limit: isize,
     ) -> Result<Vec<String>, RedisError> {
-        Ok(self
+        self
             .connection
             .zrangebyscore_limit(self.namespaced_key(key), lower, upper, offset, limit)
             .await
-            .map_err(|err| self.check_connection(err))?)
+            .map_err(|err| self.check_connection(err))
     }
 
     pub async fn zadd<V: ToRedisArgs + Send + Sync, S: ToRedisArgs + Send + Sync>(
@@ -240,11 +240,11 @@ impl RedisConnection {
         value: V,
         score: S,
     ) -> Result<usize, RedisError> {
-        Ok(self
+        self
             .connection
             .zadd(self.namespaced_key(key), value, score)
             .await
-            .map_err(|err| self.check_connection(err))?)
+            .map_err(|err| self.check_connection(err))
     }
 
     pub async fn zadd_ch<V: ToRedisArgs + Send + Sync, S: ToRedisArgs + Send + Sync>(
@@ -253,21 +253,21 @@ impl RedisConnection {
         value: V,
         score: S,
     ) -> Result<bool, RedisError> {
-        Ok(redis::cmd("ZADD")
+        redis::cmd("ZADD")
             .arg(self.namespaced_key(key))
             .arg("CH")
             .arg(score)
             .arg(value)
             .query_async(self.unnamespaced_borrow_mut())
             .await
-            .map_err(|err| self.check_connection(err))?)
+            .map_err(|err| self.check_connection(err))
     }
 
     pub async fn zrem(&mut self, key: String, value: String) -> Result<bool, RedisError> {
-        Ok(self
+        self
             .connection
             .zrem(self.namespaced_key(key), value)
             .await
-            .map_err(|err| self.check_connection(err))?)
+            .map_err(|err| self.check_connection(err))
     }
 }

--- a/src/scheduled.rs
+++ b/src/scheduled.rs
@@ -35,7 +35,7 @@ impl Scheduled {
                         "queue" => &work.queue
                     );
 
-                    work.enqueue_direct(&mut *redis).await?;
+                    work.enqueue_direct(&mut redis).await?;
                 }
             }
         }
@@ -56,7 +56,7 @@ impl Scheduled {
         for periodic_job in &periodic_jobs {
             let pj = PeriodicJob::from_periodic_job_string(periodic_job.clone())?;
 
-            if pj.update(&mut *conn, periodic_job).await? {
+            if pj.update(&mut conn, periodic_job).await? {
                 let job = pj.into_job();
                 let work = UnitOfWork::from_job(job);
 

--- a/tests/server_middleware_test.rs
+++ b/tests/server_middleware_test.rs
@@ -80,7 +80,7 @@ mod test {
             if self.should_halt {
                 return Ok(());
             } else {
-                return Ok(chain.next(job, worker, redis).await?);
+                return chain.next(job, worker, redis).await;
             }
         }
     }


### PR DESCRIPTION
~~When an IO error is detected, we should be safe to assume the connection is down and needs to be recreated. Without this, it's possible for a process to be stuck in a loop that never recovers even though redis has come back online.~~

Updating the description:

Feel free to read the log below even though the real fix is found in #26 . Some of these changes are good and you can see how clippy fixes make the code easier and maybe even faster.