### PR TITLE
remove mut requirement for RedisPool, + some lint fixes

### DIFF
--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -165,7 +165,7 @@ impl ServerMiddleware for RetryMiddleware {
         chain: ChainIter,
         job: &Job,
         worker: Arc<WorkerRef>,
-        mut redis: RedisPool,
+        redis: RedisPool,
     ) -> ServerResult {
         let max_retries = worker.max_retries();
 
@@ -199,7 +199,7 @@ impl ServerMiddleware for RetryMiddleware {
                 "err" => &job.error_message,
             );
 
-            UnitOfWork::from_job(job).reenqueue(&mut redis).await?;
+            UnitOfWork::from_job(job).reenqueue(&redis).await?;
         }
 
         Ok(())

--- a/src/periodic.rs
+++ b/src/periodic.rs
@@ -58,13 +58,15 @@ impl Builder {
             JsonValue::Array(vec![args])
         };
 
-        Ok(Builder {
+        Ok(Self {
             args: Some(args),
             ..self
         })
     }
-    pub fn retry(self, retry: bool) -> Builder {
-        Builder {
+
+    #[must_use]
+    pub fn retry(self, retry: bool) -> Self {
+        Self {
             retry: Some(retry),
             ..self
         }
@@ -183,6 +185,7 @@ impl PeriodicJob {
         .into())
     }
 
+    #[must_use]
     pub fn next_scheduled_time(&self) -> Option<f64> {
         if let Some(ref cron_sched) = self.cron_schedule {
             cron_sched
@@ -194,6 +197,7 @@ impl PeriodicJob {
         }
     }
 
+    #[must_use]
     pub fn into_job(&self) -> Job {
         let args = self.json_args.clone().expect("always set in contructor");
 

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -25,6 +25,7 @@ pub struct Processor {
 }
 
 impl Processor {
+    #[must_use]
     pub fn new(redis: RedisPool, logger: slog::Logger, queues: Vec<String>) -> Self {
         let busy_jobs = Counter::new(0);
 
@@ -102,7 +103,7 @@ impl Processor {
                 "queue" => &work.job.queue,
                 "jid" => &work.job.jid,
             );
-            work.reenqueue(&mut self.redis).await?;
+            work.reenqueue(&self.redis).await?;
         }
 
         // TODO: Make this only say "done" when the job is successful.
@@ -235,7 +236,7 @@ impl Processor {
         });
 
         loop {
-            tokio::time::sleep(std::time::Duration::from_secs(1)).await
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         }
     }
 
@@ -243,6 +244,6 @@ impl Processor {
     where
         M: ServerMiddleware + Send + Sync + 'static,
     {
-        self.chain.using(Box::new(middleware)).await
+        self.chain.using(Box::new(middleware)).await;
     }
 }

--- a/src/redis.rs
+++ b/src/redis.rs
@@ -27,6 +27,7 @@ impl CustomizeConnection<RedisConnection, RedisError> for NamespaceCustomizer {
     }
 }
 
+#[must_use]
 pub fn with_custom_namespace(namespace: String) -> Box<NamespaceCustomizer> {
     Box::new(NamespaceCustomizer { namespace })
 }
@@ -42,7 +43,7 @@ impl RedisConnectionManager {
     /// Create a new `RedisConnectionManager`.
     /// See `redis::Client::open` for a description of the parameter types.
     pub fn new<T: IntoConnectionInfo>(info: T) -> Result<Self, RedisError> {
-        Ok(RedisConnectionManager {
+        Ok(Self {
             client: Client::open(info.into_connection_info()?)?,
         })
     }
@@ -81,6 +82,7 @@ pub struct RedisConnection {
 }
 
 impl RedisConnection {
+    #[must_use]
     pub fn new(connection: Connection) -> Self {
         Self {
             connection,
@@ -92,6 +94,7 @@ impl RedisConnection {
         self.namespace = Some(namespace);
     }
 
+    #[must_use]
     pub fn with_namespace(self, namespace: String) -> Self {
         Self {
             connection: self.connection,

--- a/src/scheduled.rs
+++ b/src/scheduled.rs
@@ -7,6 +7,7 @@ pub struct Scheduled {
 }
 
 impl Scheduled {
+    #[must_use]
     pub fn new(redis: RedisPool, logger: slog::Logger) -> Self {
         Self { redis, logger }
     }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -10,20 +10,24 @@ pub struct Counter {
 }
 
 impl Counter {
+    #[must_use]
     pub fn new(n: usize) -> Self {
         Self {
             count: Arc::new(AtomicUsize::new(n)),
         }
     }
 
+    #[must_use]
     pub fn value(&self) -> usize {
         self.count.load(Ordering::SeqCst)
     }
 
+    #[must_use]
     pub fn decrby(&self, n: usize) -> usize {
         self.count.fetch_sub(n, Ordering::SeqCst)
     }
 
+    #[must_use]
     pub fn incrby(&self, n: usize) -> usize {
         self.count.fetch_add(n, Ordering::SeqCst)
     }
@@ -68,6 +72,7 @@ fn generate_identity(hostname: &String) -> String {
 }
 
 impl StatsPublisher {
+    #[must_use]
     pub fn new(hostname: String, queues: Vec<String>, busy_jobs: Counter) -> Self {
         let identity = generate_identity(&hostname);
         let started_at = chrono::Utc::now();

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -22,14 +22,12 @@ impl Counter {
         self.count.load(Ordering::SeqCst)
     }
 
-    #[must_use]
-    pub fn decrby(&self, n: usize) -> usize {
-        self.count.fetch_sub(n, Ordering::SeqCst)
+    pub fn decrby(&self, n: usize) {
+        self.count.fetch_sub(n, Ordering::SeqCst);
     }
 
-    #[must_use]
-    pub fn incrby(&self, n: usize) -> usize {
-        self.count.fetch_add(n, Ordering::SeqCst)
+    pub fn incrby(&self, n: usize) {
+        self.count.fetch_add(n, Ordering::SeqCst);
     }
 }
 


### PR DESCRIPTION
This removes the requirement for a mut pool (which did not make sense, and severely limited use through a web framework)

_NOTE_: FYI in general there are some more warnings (via lints), which indicates some of the types require `Serialize` and are not `Send`, but I left it as-is for now.
