### PR TITLE
move from slog to tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,13 +19,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.64"
+version = "0.1.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
+checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -211,7 +211,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -228,7 +228,7 @@ checksum = "ebf883b7aacd7b2aeb2a7b338648ee19f57c140d4ee8e52c68979c6b2f7f2263"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -494,6 +494,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,6 +543,16 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
 ]
 
 [[package]]
@@ -579,6 +598,12 @@ name = "once_cell"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -629,9 +654,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
@@ -653,9 +678,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -731,6 +756,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
+dependencies = [
+ "regex-syntax 0.7.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+
+[[package]]
 name = "rustversion"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,7 +793,7 @@ checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
 
 [[package]]
 name = "rusty-sidekiq"
-version = "0.7.4"
+version = "0.7.3"
 dependencies = [
  "async-trait",
  "bb8",
@@ -754,9 +809,10 @@ dependencies = [
  "serde_json",
  "sha2",
  "simple-process-stats",
- "slog",
  "slog-term",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -794,7 +850,7 @@ checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -823,6 +879,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -904,6 +969,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "term"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -940,7 +1016,7 @@ checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1035,7 +1111,7 @@ checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1054,22 +1130,76 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "cfg-if",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
 ]
 
 [[package]]
-name = "tracing-core"
-version = "0.1.30"
+name = "tracing-attributes"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -1117,6 +1247,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1155,7 +1291,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "wasm-bindgen-shared",
 ]
 
@@ -1177,7 +1313,7 @@ checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,7 +793,7 @@ checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
 
 [[package]]
 name = "rusty-sidekiq"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "async-trait",
  "bb8",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,6 +810,7 @@ dependencies = [
  "sha2",
  "simple-process-stats",
  "slog-term",
+ "thiserror",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ serde = { version = "1.0", features = ["derive"] }
 redis = { version = "0.22", features = ["aio", "default", "tokio-comp"] }
 async-trait = "0.1.74"
 slog-term = "2.9"
+thiserror = "*"
 bb8 = "0.8"
 num_cpus = "1.13"
 chrono = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty-sidekiq"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 description = "A rust sidekiq server and client using tokio"
 authors = ["Garrett Thornburg <garrett.thornburg@hey.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty-sidekiq"
-version = "0.7.4"
+version = "0.7.3"
 edition = "2021"
 description = "A rust sidekiq server and client using tokio"
 authors = ["Garrett Thornburg <garrett.thornburg@hey.com>"]
@@ -15,12 +15,11 @@ name = "sidekiq"
 
 [dependencies]
 gethostname = "0.2"
-tokio = { version = "1", features = ["full"]}
+tokio = { version = "1", features = ["full"] }
 serde_json = { version = "1" }
 serde = { version = "1.0", features = ["derive"] }
 redis = { version = "0.22", features = ["aio", "default", "tokio-comp"] }
-async-trait = "0.1"
-slog = "2.7"
+async-trait = "0.1.74"
 slog-term = "2.9"
 bb8 = "0.8"
 num_cpus = "1.13"
@@ -31,3 +30,6 @@ heck = "0.4"
 cron_clock = "0.8.0"
 simple-process-stats = "1.0.0"
 sha2 = "0.10.6"
+
+tracing = "0.1.40"
+tracing-subscriber = { version = "0.3.17", features = ["env-filter", "json"] }

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ enqueue time making it easy to change the queue name, for example, should you ne
 
 ```rust
 use tracing::info;
+use sidekiq::Result;
 
 #[derive(Clone)]
 struct PaymentReportWorker {}
@@ -27,7 +28,7 @@ impl PaymentReportWorker {
         Self { }
     }
 
-    async fn send_report(&self, user_guid: String) -> Result<(), Box<dyn std::error::Error>> {
+    async fn send_report(&self, user_guid: String) -> Result<()> {
         // TODO: Some actual work goes here...
         info!({"user_guid" = user_guid}, "Sending payment report to user");
 
@@ -48,7 +49,7 @@ impl Worker<PaymentReportArgs> for PaymentReportWorker {
     }
 
     // Worker implementation
-    async fn perform(&self, args: PaymentReportArgs) -> Result<(), Box<dyn std::error::Error>> {
+    async fn perform(&self, args: PaymentReportArgs) -> Result<()> {
         self.send_report(args.user_guid).await
     }
 }
@@ -267,6 +268,7 @@ etc. You can define these on your worker struct so long as they implement `Clone
 
 ```rust
 use tracing::debug;
+use sidekiq::Result;
 
 #[derive(Clone)]
 struct ExampleWorker {
@@ -276,7 +278,7 @@ struct ExampleWorker {
 
 #[async_trait]
 impl Worker<()> for ExampleWorker {
-    async fn perform(&self, args: PaymentReportArgs) -> Result<(), Box<dyn std::error::Error>> {
+    async fn perform(&self, args: PaymentReportArgs) -> Result<()> {
         use redis::AsyncCommands;
 
         // And then they are available here...
@@ -293,7 +295,7 @@ impl Worker<()> for ExampleWorker {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<()> {
 // ...
     let mut p = Processor::new(
         redis.clone(),
@@ -315,10 +317,11 @@ of the default trait methods:
 
 ```rust
 pub struct MyWorker;
+use sidekiq::Result;
 
 #[async_trait]
 impl Worker<()> for MyWorker {
-    async fn perform(&self, _args: ()) -> ServerResult {
+    async fn perform(&self, _args: ()) -> Result<()> {
         Ok(())
     }
 

--- a/examples/namespaced_demo.rs
+++ b/examples/namespaced_demo.rs
@@ -1,7 +1,6 @@
 use async_trait::async_trait;
 use bb8::Pool;
 use sidekiq::{Processor, RedisConnectionManager, Worker};
-use slog::{o, Drain};
 
 #[derive(Clone)]
 struct HelloWorker;
@@ -17,10 +16,7 @@ impl Worker<()> for HelloWorker {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Logger
-    let decorator = slog_term::PlainSyncDecorator::new(std::io::stdout());
-    let drain = slog_term::FullFormat::new(decorator).build().fuse();
-    let logger = slog::Logger::root(drain, o!());
+    tracing_subscriber::fmt::init();
 
     // Redis
     let manager = RedisConnectionManager::new("redis://127.0.0.1/")?;
@@ -43,7 +39,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     });
 
     // Sidekiq server
-    let mut p = Processor::new(redis.clone(), logger.clone(), vec!["default".to_string()]);
+    let mut p = Processor::new(redis.clone(), vec!["default".to_string()]);
 
     // Add known workers
     p.register(HelloWorker);

--- a/examples/namespaced_demo.rs
+++ b/examples/namespaced_demo.rs
@@ -1,13 +1,13 @@
 use async_trait::async_trait;
 use bb8::Pool;
-use sidekiq::{Processor, RedisConnectionManager, Worker};
+use sidekiq::{Processor, RedisConnectionManager, Result, Worker};
 
 #[derive(Clone)]
 struct HelloWorker;
 
 #[async_trait]
 impl Worker<()> for HelloWorker {
-    async fn perform(&self, _args: ()) -> Result<(), Box<dyn std::error::Error>> {
+    async fn perform(&self, _args: ()) -> Result<()> {
         println!("Hello, world!");
 
         Ok(())
@@ -15,7 +15,7 @@ impl Worker<()> for HelloWorker {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
 
     // Redis

--- a/examples/producer-demo.rs
+++ b/examples/producer-demo.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use bb8::Pool;
 use serde::{Deserialize, Serialize};
 use sidekiq::{
-    ChainIter, Job, RedisConnectionManager, ServerMiddleware, ServerResult, Worker, WorkerRef,
+    ChainIter, Job, RedisConnectionManager, Result, ServerMiddleware, Worker, WorkerRef,
 };
 use std::sync::Arc;
 use tracing::{error, info};
@@ -12,7 +12,7 @@ struct HelloWorker;
 
 #[async_trait]
 impl Worker<()> for HelloWorker {
-    async fn perform(&self, _args: ()) -> Result<(), Box<dyn std::error::Error>> {
+    async fn perform(&self, _args: ()) -> Result<()> {
         // I don't use any args. I do my own work.
         Ok(())
     }
@@ -22,7 +22,7 @@ impl Worker<()> for HelloWorker {
 struct PaymentReportWorker {}
 
 impl PaymentReportWorker {
-    async fn send_report(&self, user_guid: String) -> Result<(), Box<dyn std::error::Error>> {
+    async fn send_report(&self, user_guid: String) -> Result<()> {
         // TODO: Some actual work goes here...
         info!({"user_guid" = user_guid, "class_name" = Self::class_name()}, "Sending payment report to user");
 
@@ -41,7 +41,7 @@ impl Worker<PaymentReportArgs> for PaymentReportWorker {
         sidekiq::WorkerOpts::new().queue("yolo")
     }
 
-    async fn perform(&self, args: PaymentReportArgs) -> Result<(), Box<dyn std::error::Error>> {
+    async fn perform(&self, args: PaymentReportArgs) -> Result<()> {
         self.send_report(args.user_guid).await
     }
 }
@@ -67,8 +67,8 @@ impl ServerMiddleware for FilterExpiredUsersMiddleware {
         job: &Job,
         worker: Arc<WorkerRef>,
         redis: Pool<RedisConnectionManager>,
-    ) -> ServerResult {
-        let args: Result<(FiltereExpiredUsersArgs,), serde_json::Error> =
+    ) -> Result<()> {
+        let args: std::result::Result<(FiltereExpiredUsersArgs,), serde_json::Error> =
             serde_json::from_value(job.args.clone());
 
         // If we can safely deserialize then attempt to filter based on user guid.
@@ -90,7 +90,7 @@ impl ServerMiddleware for FilterExpiredUsersMiddleware {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
 
     // Redis

--- a/examples/unique.rs
+++ b/examples/unique.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use bb8::Pool;
 use serde::{Deserialize, Serialize};
-use sidekiq::{Processor, RedisConnectionManager, Worker};
+use sidekiq::{Processor, RedisConnectionManager, Result, Worker};
 
 #[derive(Clone)]
 struct CustomerNotificationWorker;
@@ -15,7 +15,7 @@ impl Worker<CustomerNotification> for CustomerNotificationWorker {
             .unique_for(std::time::Duration::from_secs(30))
     }
 
-    async fn perform(&self, _args: CustomerNotification) -> Result<(), Box<dyn std::error::Error>> {
+    async fn perform(&self, _args: CustomerNotification) -> Result<()> {
         Ok(())
     }
 }
@@ -26,7 +26,7 @@ struct CustomerNotification {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
 
     // Redis

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,8 +1,8 @@
 use crate::{Counter, Job, RedisPool, UnitOfWork, WorkerRef};
 use async_trait::async_trait;
-use slog::error;
 use std::sync::Arc;
 use tokio::sync::RwLock;
+use tracing::error;
 
 pub type ServerResult = Result<(), Box<dyn std::error::Error>>;
 
@@ -63,10 +63,10 @@ impl Chain {
         }
     }
 
-    pub(crate) fn new_with_stats(logger: slog::Logger, counter: Counter) -> Self {
+    pub(crate) fn new_with_stats(counter: Counter) -> Self {
         Self {
             stack: Arc::new(RwLock::new(vec![
-                Box::new(RetryMiddleware::new(logger)),
+                Box::new(RetryMiddleware::new()),
                 Box::new(StatsMiddleware::new(counter)),
                 Box::new(HandlerMiddleware),
             ])),
@@ -147,13 +147,11 @@ impl ServerMiddleware for HandlerMiddleware {
     }
 }
 
-struct RetryMiddleware {
-    logger: slog::Logger,
-}
+struct RetryMiddleware {}
 
 impl RetryMiddleware {
-    fn new(logger: slog::Logger) -> Self {
-        Self { logger }
+    fn new() -> Self {
+        Self {}
     }
 }
 
@@ -190,14 +188,13 @@ impl ServerMiddleware for RetryMiddleware {
 
         // Attempt the retry.
         if retry_count < max_retries {
-            error!(self.logger,
-                "Scheduling job for retry in the future";
-                "status" => "fail",
-                "class" => &job.class,
-                "jid" => &job.jid,
-                "queue" => &job.queue,
-                "err" => &job.error_message,
-            );
+            error!({
+                "status" = "fail",
+                "class" = &job.class,
+                "jid" = &job.jid,
+                "queue" = &job.queue,
+                "err" = &job.error_message
+            }, "Scheduling job for retry in the future");
 
             UnitOfWork::from_job(job).reenqueue(&redis).await?;
         }

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -1,3 +1,4 @@
+use super::Result;
 use crate::{
     periodic::PeriodicJob, Chain, Counter, Job, RedisPool, Scheduled, ServerMiddleware,
     StatsPublisher, UnitOfWork, Worker, WorkerRef,
@@ -43,7 +44,7 @@ impl Processor {
         }
     }
 
-    async fn fetch(&mut self) -> Result<Option<UnitOfWork>, Box<dyn std::error::Error>> {
+    async fn fetch(&mut self) -> Result<Option<UnitOfWork>> {
         let response: Option<(String, String)> = self
             .redis
             .get()
@@ -59,7 +60,7 @@ impl Processor {
         Ok(None)
     }
 
-    pub async fn process_one(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn process_one(&mut self) -> Result<()> {
         loop {
             if let WorkFetcher::NoWorkFound = self.process_one_tick_once().await? {
                 continue;
@@ -69,9 +70,7 @@ impl Processor {
         }
     }
 
-    pub async fn process_one_tick_once(
-        &mut self,
-    ) -> Result<WorkFetcher, Box<dyn std::error::Error>> {
+    pub async fn process_one_tick_once(&mut self) -> Result<WorkFetcher> {
         let work = self.fetch().await?;
 
         if work.is_none() {
@@ -126,10 +125,7 @@ impl Processor {
             .insert(W::class_name(), Arc::new(WorkerRef::wrap(Arc::new(worker))));
     }
 
-    pub(crate) async fn register_periodic(
-        &mut self,
-        periodic_job: PeriodicJob,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    pub(crate) async fn register_periodic(&mut self, periodic_job: PeriodicJob) -> Result<()> {
         self.periodic_jobs.push(periodic_job.clone());
 
         let mut conn = self.redis.get().await?;

--- a/tests/process_async_test.rs
+++ b/tests/process_async_test.rs
@@ -3,7 +3,6 @@ mod test {
     use async_trait::async_trait;
     use bb8::Pool;
     use sidekiq::{Processor, RedisConnectionManager, RedisPool, WorkFetcher, Worker};
-    use slog::{o, Drain};
     use std::sync::{Arc, Mutex};
 
     #[async_trait]
@@ -22,21 +21,16 @@ mod test {
         }
     }
 
-    async fn new_base_processor(queue: String) -> (Processor, RedisPool, slog::Logger) {
-        // Logger
-        let decorator = slog_term::PlainSyncDecorator::new(std::io::stdout());
-        let drain = slog_term::FullFormat::new(decorator).build().fuse();
-        let logger = slog::Logger::root(drain, o!());
-
+    async fn new_base_processor(queue: String) -> (Processor, RedisPool) {
         // Redis
         let manager = RedisConnectionManager::new("redis://127.0.0.1/").unwrap();
         let redis = Pool::builder().build(manager).await.unwrap();
         redis.flushall().await;
 
         // Sidekiq server
-        let p = Processor::new(redis.clone(), logger.clone(), vec![queue]);
+        let p = Processor::new(redis.clone(), vec![queue]);
 
-        (p, redis, logger)
+        (p, redis)
     }
 
     #[tokio::test]
@@ -60,7 +54,7 @@ mod test {
             did_process: Arc::new(Mutex::new(false)),
         };
         let queue = "random123".to_string();
-        let (mut p, mut redis, _) = new_base_processor(queue.clone()).await;
+        let (mut p, mut redis) = new_base_processor(queue.clone()).await;
 
         p.register(worker.clone());
 

--- a/tests/process_async_test.rs
+++ b/tests/process_async_test.rs
@@ -2,7 +2,7 @@
 mod test {
     use async_trait::async_trait;
     use bb8::Pool;
-    use sidekiq::{Processor, RedisConnectionManager, RedisPool, WorkFetcher, Worker};
+    use sidekiq::{Processor, RedisConnectionManager, RedisPool, Result, WorkFetcher, Worker};
     use std::sync::{Arc, Mutex};
 
     #[async_trait]
@@ -42,7 +42,7 @@ mod test {
 
         #[async_trait]
         impl Worker<()> for TestWorker {
-            async fn perform(&self, _args: ()) -> Result<(), Box<dyn std::error::Error>> {
+            async fn perform(&self, _args: ()) -> Result<()> {
                 let mut this = self.did_process.lock().unwrap();
                 *this = true;
 

--- a/tests/process_cron_job_test.rs
+++ b/tests/process_cron_job_test.rs
@@ -5,7 +5,6 @@ mod test {
     use sidekiq::{
         periodic, Processor, RedisConnectionManager, RedisPool, Scheduled, WorkFetcher, Worker,
     };
-    use slog::{o, Drain};
     use std::sync::{Arc, Mutex};
 
     #[async_trait]
@@ -24,21 +23,16 @@ mod test {
         }
     }
 
-    async fn new_base_processor(queue: String) -> (Processor, RedisPool, slog::Logger) {
-        // Logger
-        let decorator = slog_term::PlainSyncDecorator::new(std::io::stdout());
-        let drain = slog_term::FullFormat::new(decorator).build().fuse();
-        let logger = slog::Logger::root(drain, o!());
-
+    async fn new_base_processor(queue: String) -> (Processor, RedisPool) {
         // Redis
         let manager = RedisConnectionManager::new("redis://127.0.0.1/").unwrap();
         let redis = Pool::builder().build(manager).await.unwrap();
         redis.flushall().await;
 
         // Sidekiq server
-        let p = Processor::new(redis.clone(), logger.clone(), vec![queue]);
+        let p = Processor::new(redis.clone(), vec![queue]);
 
-        (p, redis, logger)
+        (p, redis)
     }
 
     async fn set_cron_scores_to_zero(redis: RedisPool) {
@@ -78,7 +72,7 @@ mod test {
             did_process: Arc::new(Mutex::new(false)),
         };
         let queue = "random123".to_string();
-        let (mut p, redis, logger) = new_base_processor(queue.clone()).await;
+        let (mut p, redis) = new_base_processor(queue.clone()).await;
 
         p.register(worker.clone());
 
@@ -98,7 +92,7 @@ mod test {
 
         set_cron_scores_to_zero(redis.clone()).await;
 
-        let sched = Scheduled::new(redis.clone(), logger.clone());
+        let sched = Scheduled::new(redis.clone());
         let n = sched
             .enqueue_periodic_jobs(chrono::Utc::now())
             .await

--- a/tests/process_cron_job_test.rs
+++ b/tests/process_cron_job_test.rs
@@ -3,7 +3,8 @@ mod test {
     use async_trait::async_trait;
     use bb8::Pool;
     use sidekiq::{
-        periodic, Processor, RedisConnectionManager, RedisPool, Scheduled, WorkFetcher, Worker,
+        periodic, Processor, RedisConnectionManager, RedisPool, Result, Scheduled, WorkFetcher,
+        Worker,
     };
     use std::sync::{Arc, Mutex};
 
@@ -60,7 +61,7 @@ mod test {
 
         #[async_trait]
         impl Worker<()> for TestWorker {
-            async fn perform(&self, _args: ()) -> Result<(), Box<dyn std::error::Error>> {
+            async fn perform(&self, _args: ()) -> Result<()> {
                 let mut this = self.did_process.lock().unwrap();
                 *this = true;
 

--- a/tests/process_scheduled_job_test.rs
+++ b/tests/process_scheduled_job_test.rs
@@ -3,7 +3,6 @@ mod test {
     use async_trait::async_trait;
     use bb8::Pool;
     use sidekiq::{Processor, RedisConnectionManager, RedisPool, Scheduled, WorkFetcher, Worker};
-    use slog::{o, Drain};
     use std::sync::{Arc, Mutex};
 
     #[async_trait]
@@ -22,21 +21,16 @@ mod test {
         }
     }
 
-    async fn new_base_processor(queue: String) -> (Processor, RedisPool, slog::Logger) {
-        // Logger
-        let decorator = slog_term::PlainSyncDecorator::new(std::io::stdout());
-        let drain = slog_term::FullFormat::new(decorator).build().fuse();
-        let logger = slog::Logger::root(drain, o!());
-
+    async fn new_base_processor(queue: String) -> (Processor, RedisPool) {
         // Redis
         let manager = RedisConnectionManager::new("redis://127.0.0.1/").unwrap();
         let redis = Pool::builder().build(manager).await.unwrap();
         redis.flushall().await;
 
         // Sidekiq server
-        let p = Processor::new(redis.clone(), logger.clone(), vec![queue]);
+        let p = Processor::new(redis.clone(), vec![queue]);
 
-        (p, redis, logger)
+        (p, redis)
     }
 
     #[tokio::test]
@@ -60,7 +54,7 @@ mod test {
             did_process: Arc::new(Mutex::new(false)),
         };
         let queue = "random123".to_string();
-        let (mut p, mut redis, logger) = new_base_processor(queue.clone()).await;
+        let (mut p, mut redis) = new_base_processor(queue.clone()).await;
 
         p.register(worker.clone());
 
@@ -75,7 +69,7 @@ mod test {
             WorkFetcher::NoWorkFound
         );
 
-        let sched = Scheduled::new(redis.clone(), logger.clone());
+        let sched = Scheduled::new(redis.clone());
         let sorted_sets = vec!["retry".to_string(), "schedule".to_string()];
         let n = sched
             .enqueue_jobs(

--- a/tests/process_scheduled_job_test.rs
+++ b/tests/process_scheduled_job_test.rs
@@ -2,7 +2,9 @@
 mod test {
     use async_trait::async_trait;
     use bb8::Pool;
-    use sidekiq::{Processor, RedisConnectionManager, RedisPool, Scheduled, WorkFetcher, Worker};
+    use sidekiq::{
+        Processor, RedisConnectionManager, RedisPool, Result, Scheduled, WorkFetcher, Worker,
+    };
     use std::sync::{Arc, Mutex};
 
     #[async_trait]
@@ -42,7 +44,7 @@ mod test {
 
         #[async_trait]
         impl Worker<()> for TestWorker {
-            async fn perform(&self, _args: ()) -> Result<(), Box<dyn std::error::Error>> {
+            async fn perform(&self, _args: ()) -> Result<()> {
                 let mut this = self.did_process.lock().unwrap();
                 *this = true;
 

--- a/tests/process_unique_job_test.rs
+++ b/tests/process_unique_job_test.rs
@@ -3,7 +3,6 @@ mod test {
     use async_trait::async_trait;
     use bb8::Pool;
     use sidekiq::{Processor, RedisConnectionManager, RedisPool, WorkFetcher, Worker};
-    use slog::{o, Drain};
     use std::sync::{Arc, Mutex};
 
     #[async_trait]
@@ -22,21 +21,16 @@ mod test {
         }
     }
 
-    async fn new_base_processor(queue: String) -> (Processor, RedisPool, slog::Logger) {
-        // Logger
-        let decorator = slog_term::PlainSyncDecorator::new(std::io::stdout());
-        let drain = slog_term::FullFormat::new(decorator).build().fuse();
-        let logger = slog::Logger::root(drain, o!());
-
+    async fn new_base_processor(queue: String) -> (Processor, RedisPool) {
         // Redis
         let manager = RedisConnectionManager::new("redis://127.0.0.1/").unwrap();
         let redis = Pool::builder().build(manager).await.unwrap();
         redis.flushall().await;
 
         // Sidekiq server
-        let p = Processor::new(redis.clone(), logger.clone(), vec![queue]);
+        let p = Processor::new(redis.clone(), vec![queue]);
 
-        (p, redis, logger)
+        (p, redis)
     }
 
     #[tokio::test]
@@ -60,7 +54,7 @@ mod test {
             did_process: Arc::new(Mutex::new(false)),
         };
         let queue = "random123".to_string();
-        let (mut p, mut redis, _) = new_base_processor(queue.clone()).await;
+        let (mut p, mut redis) = new_base_processor(queue.clone()).await;
 
         p.register(worker.clone());
 

--- a/tests/process_unique_job_test.rs
+++ b/tests/process_unique_job_test.rs
@@ -2,7 +2,7 @@
 mod test {
     use async_trait::async_trait;
     use bb8::Pool;
-    use sidekiq::{Processor, RedisConnectionManager, RedisPool, WorkFetcher, Worker};
+    use sidekiq::{Processor, RedisConnectionManager, RedisPool, Result, WorkFetcher, Worker};
     use std::sync::{Arc, Mutex};
 
     #[async_trait]
@@ -42,7 +42,7 @@ mod test {
 
         #[async_trait]
         impl Worker<()> for TestWorker {
-            async fn perform(&self, _args: ()) -> Result<(), Box<dyn std::error::Error>> {
+            async fn perform(&self, _args: ()) -> Result<()> {
                 let mut this = self.did_process.lock().unwrap();
                 *this = true;
 

--- a/tests/server_middleware_test.rs
+++ b/tests/server_middleware_test.rs
@@ -3,8 +3,8 @@ mod test {
     use async_trait::async_trait;
     use bb8::Pool;
     use sidekiq::{
-        ChainIter, Job, Processor, RedisConnectionManager, RedisPool, ServerMiddleware,
-        ServerResult, WorkFetcher, Worker, WorkerRef,
+        ChainIter, Job, Processor, RedisConnectionManager, RedisPool, Result, ServerMiddleware,
+        WorkFetcher, Worker, WorkerRef,
     };
     use std::sync::{Arc, Mutex};
 
@@ -43,7 +43,7 @@ mod test {
 
     #[async_trait]
     impl Worker<()> for TestWorker {
-        async fn perform(&self, _args: ()) -> Result<(), Box<dyn std::error::Error>> {
+        async fn perform(&self, _args: ()) -> Result<()> {
             let mut this = self.did_process.lock().unwrap();
             *this = true;
 
@@ -65,7 +65,7 @@ mod test {
             job: &Job,
             worker: Arc<WorkerRef>,
             redis: RedisPool,
-        ) -> ServerResult {
+        ) -> Result<()> {
             {
                 let mut this = self.did_process.lock().unwrap();
                 *this = true;


### PR DESCRIPTION
This PR moves from `slog` to `tracing` across the board.

Benefits:

* Move to more "standardized" logging
* Inversion of control - publisher-subscriber model, no longer need to pass `logger` around
* All the power and flexibility of tracing and opentracing at hand (filtering, formatting, collection, shipping to OTEL, and more)
* Integrate into production deployments better: one tracing filter/level to rule them all (i.e. filter across libraries such as sqlx)
* Opens up the possibility of `spans` across jobs, components and advanced instrumentation
* Removal of a good amount of code and an _aging_ infrastructure (slog, `log`)