### PR TITLE
expose base redis lib

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ mod stats;
 pub use crate::redis::{
     with_custom_namespace, RedisConnection, RedisConnectionManager, RedisError, RedisPool,
 };
+pub use ::redis as redis_rs;
 pub use middleware::{ChainIter, ServerMiddleware};
 pub use processor::{Processor, WorkFetcher};
 pub use scheduled::Scheduled;


### PR DESCRIPTION
This pull request enhances the redis_rs library by enabling the utilization of a specified Redis version. This is achieved by allowing additional commands to be executed before registration. For instance, one can use the 'flushall' command as an example of a pre-registration command.

For example, I want to run this logic before registering:
```
    if let Some(pool) = &redis {
        let mut conn = pool.get().await.unwrap();
        sidekiq::redis_rs::cmd("FLUSHDB")
            .query_async::<_, ()>(conn.unnamespaced_borrow_mut())
            .await
            .unwrap();
    }
```