### PR TITLE
making simple-process-stats optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,11 @@ keywords = ["sidekiq", "worker", "tokio", "ruby"]
 license = "MIT"
 readme = "README.md"
 
+[features]
+default = ["rss-stats"]
+
+rss-stats = ["dep:simple-process-stats"]
+
 [lib]
 name = "sidekiq"
 
@@ -29,7 +34,7 @@ rand = "0.8"
 hex = "0.4"
 heck = "0.4"
 cron_clock = "0.8.0"
-simple-process-stats = "1.0.0"
+simple-process-stats = { version = "1.0.0", optional = true }
 sha2 = "0.10.6"
 
 tracing = "0.1.40"

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -123,6 +123,7 @@ impl StatsPublisher {
     }
 
     async fn create_process_stats(&self) -> Result<ProcessStats, Box<dyn std::error::Error>> {
+        #[cfg(feature = "rss-stats")]
         let rss_in_kb = format!(
             "{}",
             simple_process_stats::ProcessStats::get()
@@ -130,6 +131,9 @@ impl StatsPublisher {
                 .memory_usage_bytes
                 / 1024
         );
+
+        #[cfg(not(feature = "rss-stats"))]
+        let rss_in_kb = "0".to_string();
 
         Ok(ProcessStats {
             rtt_us: "0".into(),


### PR DESCRIPTION
Hi,
There is a dependency issue, which causes unresolvable Cargo conflicts on macOS caused by a transitive dependency of `simple-process-stats`:

* see https://github.com/heim-rs/darwin-libproc/pull/9 on the core dependency issue, and the fact that `darwin-libproc` is not maintained actively to fix it
* sidekiq-rs needs `robotty/simple-process-stats` which depends on `darwin-libproc`, which depends on
a too old `memchr` version which many libraries, one example: `sqlx` needs. because `libproc` is native and not pure rust, cargo cannot resolve it.


since `simple_process_stats` use by `sidekiq-rs` is minimal only for getting `RSS`, its better to replace it with something that has more velocity on updating dependencies but that is also lightweight and cross platform (I didn't find one yet).

in the meanwhile as a workaround, I put the dependency under an optional flag -- enabled by a feature. this feature is by-default turned on so no one will notice.

in our codebase, we can disable this feature, which disables `simple-process-stats`, and our build passes nicely.
