### PR TITLE
Switch case lib due to bug with ruby style X1Y1Class shapes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,6 +143,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,12 +382,6 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
 ]
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -798,9 +801,9 @@ dependencies = [
  "async-trait",
  "bb8",
  "chrono",
+ "convert_case",
  "cron_clock",
  "gethostname",
- "heck",
  "hex",
  "num_cpus",
  "rand",
@@ -1229,6 +1232,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,10 +34,10 @@ num_cpus = "1.13"
 chrono = "0.4"
 rand = "0.8"
 hex = "0.4"
-heck = "0.4"
 cron_clock = "0.8.0"
 simple-process-stats = { version = "1.0.0", optional = true }
 sha2 = "0.10.6"
+convert_case = "0.6.0"
 
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter", "json"] }


### PR DESCRIPTION
By switching from heck to convert_case we auto-fix this issue. The test case shows what was previously _not_ working and how convert_case does work. I spent some time going through the heck library but convert_case seems very popular and "just works" out of the box.

Closes https://github.com/film42/sidekiq-rs/issues/30