### PR TITLE
Fix off-by-one error for max retries check

### DIFF
--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -180,7 +180,15 @@ impl ServerMiddleware for RetryMiddleware {
         job.retry_count = Some(retry_count);
 
         // Attempt the retry.
-        if retry_count < max_retries {
+        if retry_count > max_retries {
+            error!({
+                "status" = "fail",
+                "class" = &job.class,
+                "jid" = &job.jid,
+                "queue" = &job.queue,
+                "err" = &job.error_message
+            }, "Max retries exceeded, will not reschedule job");
+        } else {
             error!({
                 "status" = "fail",
                 "class" = &job.class,


### PR DESCRIPTION
Problem
--------
The `retry_count < max_retries` check is performed after `retry_count` is incremented. This means we need to use `<=` (or equivalently `>` with the conditional blocks reversed) to check if the max retries was exceeded. Otherwise, we will have an off-by-one error in the check.

For example, if we have `max_retries = 1`, `retry_count` will be incremented to equal `1` before the check, the check will fail because `retry_count(1) == max_retries(1)` and not `<`, and therefore the job will not retry.

Solution
--------
Flip the conditional blocks and use `retry_count > max_retries` so the check will fail as expected when the `max_retries` is exceeded and not before.

I also noticed that no error log is emitted when the job fails and the `max_retries` is exceeded, so I added a log for this case.