### PR TITLE
Allow RedisConnection methods to accept ToRedisArgs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -464,7 +464,7 @@ impl UnitOfWork {
                 &job.queue, &job.class, &args_hash
             );
             if let redis::RedisValue::Nil = redis
-                .set_nx_ex(redis_key, "".into(), duration.as_secs() as usize)
+                .set_nx_ex(redis_key, "", duration.as_secs() as usize)
                 .await?
             {
                 // This job has already been enqueued. Do not submit it to redis.

--- a/src/redis.rs
+++ b/src/redis.rs
@@ -154,20 +154,29 @@ impl RedisConnection {
             .await
     }
 
-    pub async fn lpush(&mut self, key: String, value: String) -> Result<(), RedisError> {
+    pub async fn lpush<V>(&mut self, key: String, value: V) -> Result<(), RedisError>
+    where
+        V: ToRedisArgs + Send + Sync,
+    {
         self.connection.lpush(self.namespaced_key(key), value).await
     }
 
-    pub async fn sadd(&mut self, key: String, value: String) -> Result<(), RedisError> {
+    pub async fn sadd<V>(&mut self, key: String, value: V) -> Result<(), RedisError>
+    where
+        V: ToRedisArgs + Send + Sync,
+    {
         self.connection.sadd(self.namespaced_key(key), value).await
     }
 
-    pub async fn set_nx_ex(
+    pub async fn set_nx_ex<V>(
         &mut self,
         key: String,
-        value: String,
+        value: V,
         ttl_in_seconds: usize,
-    ) -> Result<RedisValue, RedisError> {
+    ) -> Result<RedisValue, RedisError>
+    where
+        V: ToRedisArgs + Send + Sync,
+    {
         redis::cmd("SET")
             .arg(self.namespaced_key(key))
             .arg(value)
@@ -228,11 +237,10 @@ impl RedisConnection {
             .await
     }
 
-    pub async fn zrem<V: ToRedisArgs + Send + Sync>(
-        &mut self,
-        key: String,
-        value: V,
-    ) -> Result<bool, RedisError> {
+    pub async fn zrem<V>(&mut self, key: String, value: V) -> Result<bool, RedisError>
+    where
+        V: ToRedisArgs + Send + Sync,
+    {
         self.connection.zrem(self.namespaced_key(key), value).await
     }
 }

--- a/src/redis.rs
+++ b/src/redis.rs
@@ -228,7 +228,11 @@ impl RedisConnection {
             .await
     }
 
-    pub async fn zrem(&mut self, key: String, value: String) -> Result<bool, RedisError> {
+    pub async fn zrem<V: ToRedisArgs + Send + Sync>(
+        &mut self,
+        key: String,
+        value: V,
+    ) -> Result<bool, RedisError> {
         self.connection.zrem(self.namespaced_key(key), value).await
     }
 }


### PR DESCRIPTION
Problem
-------
Curently, `RedisConnection::zrem` only accepts a single string as an argument. This means, in order to remove multiple items, the method needs to be called multiple times. Alternatively, one can use the underlying connection via `RedisConnection::unnamespaced_borrow_mut`, which accepts any `ToRedisArgs` type. However, then the key is not namespaced. 

Solution
--------
Allow `RedisConnection::zrem` to accept any `ToRedisArgs` like the other methods in `RedisConnection` do already.

Also updates other `RedisConnection` methods that only accept a single string value to accept `ToRedisArgs` instead.