### PR TITLE
Allow configuring the number of tasks spawned for workers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub use crate::redis::{
 };
 pub use ::redis as redis_rs;
 pub use middleware::{ChainIter, ServerMiddleware};
-pub use processor::{Processor, WorkFetcher};
+pub use processor::{Processor, ProcessorConfig, WorkFetcher};
 pub use scheduled::Scheduled;
 pub use stats::{Counter, StatsPublisher};
 


### PR DESCRIPTION
Problem
-------
If an app's workload is largely IO bound (querying a DB, making web requests and waiting for responses, etc), its workers will spend a large percentage of time idle `await`ing for futures to complete. This in turn means the will CPU sit idle a large percentage of the time (if nothing else is running on the host), resulting in under-utilizing available CPU resources.

Solution
--------
Allow apps to configure the number of tokio tasks that are spawned for workers. This will allow the app to configure the processor to use CPU resources more efficiently. For backwards compatiblity and in order to provide a sane/safe default, the default number of workers if not provided is the host's CPU count.