### PR TITLE
Remove unnecessary `mut` from examples

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -116,15 +116,15 @@ async fn main() -> Result<()> {
 
     // Redis
     let manager = RedisConnectionManager::new("redis://127.0.0.1/")?;
-    let mut redis = Pool::builder().build(manager).await?;
+    let redis = Pool::builder().build(manager).await?;
 
     tokio::spawn({
-        let mut redis = redis.clone();
+        let redis = redis.clone();
 
         async move {
             loop {
                 PaymentReportWorker::perform_async(
-                    &mut redis,
+                    &redis,
                     PaymentReportArgs {
                         user_guid: "USR-123".into(),
                     },
@@ -139,7 +139,7 @@ async fn main() -> Result<()> {
 
     // Enqueue a job with the worker! There are many ways to do this.
     PaymentReportWorker::perform_async(
-        &mut redis,
+        &redis,
         PaymentReportArgs {
             user_guid: "USR-123".into(),
         },
@@ -147,7 +147,7 @@ async fn main() -> Result<()> {
     .await?;
 
     PaymentReportWorker::perform_in(
-        &mut redis,
+        &redis,
         std::time::Duration::from_secs(10),
         PaymentReportArgs {
             user_guid: "USR-123".into(),
@@ -158,7 +158,7 @@ async fn main() -> Result<()> {
     PaymentReportWorker::opts()
         .queue("brolo")
         .perform_async(
-            &mut redis,
+            &redis,
             PaymentReportArgs {
                 user_guid: "USR-123-EXPIRED".into(),
             },
@@ -166,7 +166,7 @@ async fn main() -> Result<()> {
         .await?;
 
     sidekiq::perform_async(
-        &mut redis,
+        &redis,
         "PaymentReportWorker".into(),
         "yolo".into(),
         PaymentReportArgs {
@@ -177,7 +177,7 @@ async fn main() -> Result<()> {
 
     // Enqueue a job
     sidekiq::perform_async(
-        &mut redis,
+        &redis,
         "PaymentReportWorker".into(),
         "yolo".into(),
         PaymentReportArgs {
@@ -190,7 +190,7 @@ async fn main() -> Result<()> {
     sidekiq::opts()
         .queue("yolo".to_string())
         .perform_async(
-            &mut redis,
+            &redis,
             "PaymentReportWorker".into(),
             PaymentReportArgs {
                 user_guid: "USR-123".to_string(),

--- a/examples/namespaced_demo.rs
+++ b/examples/namespaced_demo.rs
@@ -27,11 +27,11 @@ async fn main() -> Result<()> {
         .await?;
 
     tokio::spawn({
-        let mut redis = redis.clone();
+        let redis = redis.clone();
 
         async move {
             loop {
-                HelloWorker::perform_async(&mut redis, ()).await.unwrap();
+                HelloWorker::perform_async(&redis, ()).await.unwrap();
 
                 tokio::time::sleep(std::time::Duration::from_secs(1)).await;
             }

--- a/examples/producer-demo.rs
+++ b/examples/producer-demo.rs
@@ -95,7 +95,7 @@ async fn main() -> Result<()> {
 
     // Redis
     let manager = RedisConnectionManager::new("redis://127.0.0.1/")?;
-    let mut redis = Pool::builder().build(manager).await?;
+    let redis = Pool::builder().build(manager).await?;
 
     let mut n = 0;
     let mut last = 0;
@@ -103,7 +103,7 @@ async fn main() -> Result<()> {
 
     loop {
         PaymentReportWorker::perform_async(
-            &mut redis,
+            &redis,
             PaymentReportArgs {
                 user_guid: "USR-123".into(),
             },

--- a/examples/unique.rs
+++ b/examples/unique.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<()> {
 
     // Redis
     let manager = RedisConnectionManager::new("redis://127.0.0.1/")?;
-    let mut redis = Pool::builder().build(manager).await?;
+    let redis = Pool::builder().build(manager).await?;
 
     // Sidekiq server
     let mut p = Processor::new(redis.clone(), vec!["customers".to_string()]);
@@ -43,7 +43,7 @@ async fn main() -> Result<()> {
     // one of these should be created within a 30 second period.
     for _ in 1..10 {
         CustomerNotificationWorker::perform_async(
-            &mut redis,
+            &redis,
             CustomerNotification {
                 customer_guid: "CST-123".to_string(),
             },

--- a/tests/process_async_test.rs
+++ b/tests/process_async_test.rs
@@ -54,13 +54,13 @@ mod test {
             did_process: Arc::new(Mutex::new(false)),
         };
         let queue = "random123".to_string();
-        let (mut p, mut redis) = new_base_processor(queue.clone()).await;
+        let (mut p, redis) = new_base_processor(queue.clone()).await;
 
         p.register(worker.clone());
 
         TestWorker::opts()
             .queue(queue)
-            .perform_async(&mut redis, ())
+            .perform_async(&redis, ())
             .await
             .unwrap();
 

--- a/tests/process_scheduled_job_test.rs
+++ b/tests/process_scheduled_job_test.rs
@@ -56,13 +56,13 @@ mod test {
             did_process: Arc::new(Mutex::new(false)),
         };
         let queue = "random123".to_string();
-        let (mut p, mut redis) = new_base_processor(queue.clone()).await;
+        let (mut p, redis) = new_base_processor(queue.clone()).await;
 
         p.register(worker.clone());
 
         TestWorker::opts()
             .queue(queue)
-            .perform_in(&mut redis, std::time::Duration::from_secs(10), ())
+            .perform_in(&redis, std::time::Duration::from_secs(10), ())
             .await
             .unwrap();
 

--- a/tests/process_unique_job_test.rs
+++ b/tests/process_unique_job_test.rs
@@ -54,14 +54,14 @@ mod test {
             did_process: Arc::new(Mutex::new(false)),
         };
         let queue = "random123".to_string();
-        let (mut p, mut redis) = new_base_processor(queue.clone()).await;
+        let (mut p, redis) = new_base_processor(queue.clone()).await;
 
         p.register(worker.clone());
 
         TestWorker::opts()
             .queue(queue.clone())
             .unique_for(std::time::Duration::from_secs(5))
-            .perform_async(&mut redis, ())
+            .perform_async(&redis, ())
             .await
             .unwrap();
 
@@ -71,7 +71,7 @@ mod test {
         TestWorker::opts()
             .queue(queue)
             .unique_for(std::time::Duration::from_secs(5))
-            .perform_async(&mut redis, ())
+            .perform_async(&redis, ())
             .await
             .unwrap();
 

--- a/tests/server_middleware_test.rs
+++ b/tests/server_middleware_test.rs
@@ -112,7 +112,7 @@ mod test {
             did_process: Arc::new(Mutex::new(false)),
         };
         let queue = "random123".to_string();
-        let (mut p, mut redis) = new_base_processor(queue.clone()).await;
+        let (mut p, redis) = new_base_processor(queue.clone()).await;
 
         let middleware = TestMiddleware {
             should_halt: true,
@@ -124,7 +124,7 @@ mod test {
 
         TestWorker::opts()
             .queue(queue)
-            .perform_async(&mut redis, ())
+            .perform_async(&redis, ())
             .await
             .unwrap();
 


### PR DESCRIPTION
`mut` was removed from `Worker#perform*` methods in [PR 28](https://github.com/film42/sidekiq-rs/pull/28). However, it was not removed from some of the examples. This PR removes the now unnecessary `mut`s.