### PR TITLE
Fix type of retry option: `retry` can be boolean or a number

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,14 +57,14 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub fn opts() -> EnqueueOpts {
     EnqueueOpts {
         queue: "default".into(),
-        retry: true,
+        retry: JsonValue::Bool(true),
         unique_for: None,
     }
 }
 
 pub struct EnqueueOpts {
     queue: String,
-    retry: bool,
+    retry: JsonValue,
     unique_for: Option<std::time::Duration>,
 }
 
@@ -78,7 +78,7 @@ impl EnqueueOpts {
     }
 
     #[must_use]
-    pub fn retry(self, retry: bool) -> Self {
+    pub fn retry(self, retry: JsonValue) -> Self {
         Self { retry, ..self }
     }
 
@@ -106,7 +106,7 @@ impl EnqueueOpts {
             jid: new_jid(),
             created_at: chrono::Utc::now().timestamp() as f64,
             enqueued_at: None,
-            retry: self.retry,
+            retry: self.retry.clone(),
             args,
 
             // Make default eventually...
@@ -178,7 +178,7 @@ fn new_jid() -> String {
 
 pub struct WorkerOpts<Args, W: Worker<Args> + ?Sized> {
     queue: String,
-    retry: bool,
+    retry: JsonValue,
     args: PhantomData<Args>,
     worker: PhantomData<W>,
     unique_for: Option<std::time::Duration>,
@@ -192,7 +192,7 @@ where
     pub fn new() -> Self {
         Self {
             queue: "default".into(),
-            retry: true,
+            retry: JsonValue::Bool(true),
             args: PhantomData,
             worker: PhantomData,
             unique_for: None,
@@ -200,7 +200,7 @@ where
     }
 
     #[must_use]
-    pub fn retry(self, retry: bool) -> Self {
+    pub fn retry(self, retry: JsonValue) -> Self {
         Self { retry, ..self }
     }
 
@@ -250,7 +250,7 @@ where
 impl<Args, W: Worker<Args>> From<&WorkerOpts<Args, W>> for EnqueueOpts {
     fn from(opts: &WorkerOpts<Args, W>) -> Self {
         Self {
-            retry: opts.retry,
+            retry: opts.retry.clone(),
             queue: opts.queue.clone(),
             unique_for: opts.unique_for,
         }
@@ -410,7 +410,7 @@ impl WorkerRef {
 pub struct Job {
     pub queue: String,
     pub args: JsonValue,
-    pub retry: bool,
+    pub retry: JsonValue,
     pub class: String,
     pub jid: String,
     pub created_at: f64,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,14 +57,14 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub fn opts() -> EnqueueOpts {
     EnqueueOpts {
         queue: "default".into(),
-        retry: JsonValue::Bool(true),
+        retry: RetryOpts::Yes,
         unique_for: None,
     }
 }
 
 pub struct EnqueueOpts {
     queue: String,
-    retry: JsonValue,
+    retry: RetryOpts,
     unique_for: Option<std::time::Duration>,
 }
 
@@ -78,8 +78,14 @@ impl EnqueueOpts {
     }
 
     #[must_use]
-    pub fn retry(self, retry: JsonValue) -> Self {
-        Self { retry, ..self }
+    pub fn retry<RO>(self, retry: RO) -> Self
+    where
+        RO: Into<RetryOpts>,
+    {
+        Self {
+            retry: retry.into(),
+            ..self
+        }
     }
 
     #[must_use]
@@ -178,7 +184,7 @@ fn new_jid() -> String {
 
 pub struct WorkerOpts<Args, W: Worker<Args> + ?Sized> {
     queue: String,
-    retry: JsonValue,
+    retry: RetryOpts,
     args: PhantomData<Args>,
     worker: PhantomData<W>,
     unique_for: Option<std::time::Duration>,
@@ -192,7 +198,7 @@ where
     pub fn new() -> Self {
         Self {
             queue: "default".into(),
-            retry: JsonValue::Bool(true),
+            retry: RetryOpts::Yes,
             args: PhantomData,
             worker: PhantomData,
             unique_for: None,
@@ -200,8 +206,14 @@ where
     }
 
     #[must_use]
-    pub fn retry(self, retry: JsonValue) -> Self {
-        Self { retry, ..self }
+    pub fn retry<RO>(self, retry: RO) -> Self
+    where
+        RO: Into<RetryOpts>,
+    {
+        Self {
+            retry: retry.into(),
+            ..self
+        }
     }
 
     #[must_use]
@@ -391,6 +403,31 @@ impl WorkerRef {
     }
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum RetryOpts {
+    #[serde(rename = "true")]
+    Yes,
+    #[serde(rename = "false")]
+    Never,
+    Max(usize),
+}
+
+impl From<bool> for RetryOpts {
+    fn from(value: bool) -> Self {
+        match value {
+            true => RetryOpts::Yes,
+            false => RetryOpts::Never,
+        }
+    }
+}
+
+impl From<usize> for RetryOpts {
+    fn from(value: usize) -> Self {
+        RetryOpts::Max(value)
+    }
+}
+
 //
 // {
 //   "retry": true,
@@ -410,7 +447,7 @@ impl WorkerRef {
 pub struct Job {
     pub queue: String,
     pub args: JsonValue,
-    pub retry: JsonValue,
+    pub retry: RetryOpts,
     pub class: String,
     pub jid: String,
     pub created_at: f64,
@@ -532,6 +569,30 @@ mod test {
         pub mod cool {
             pub mod workers {
                 use super::super::super::super::*;
+
+                pub struct TestOpts;
+
+                #[async_trait]
+                impl Worker<()> for TestOpts {
+                    fn opts() -> WorkerOpts<(), Self>
+                    where
+                        Self: Sized,
+                    {
+                        WorkerOpts::new()
+                            // Test bool
+                            .retry(false)
+                            // Test usize
+                            .retry(42)
+                            // Test the new type
+                            .retry(RetryOpts::Never)
+                            .unique_for(std::time::Duration::from_secs(30))
+                            .queue("yolo_quue")
+                    }
+
+                    async fn perform(&self, _args: ()) -> Result<()> {
+                        Ok(())
+                    }
+                }
 
                 pub struct X1Y2MyJob;
 

--- a/src/periodic.rs
+++ b/src/periodic.rs
@@ -19,7 +19,7 @@ pub struct Builder {
     pub(crate) name: Option<String>,
     pub(crate) queue: Option<String>,
     pub(crate) args: Option<JsonValue>,
-    pub(crate) retry: Option<bool>,
+    pub(crate) retry: Option<JsonValue>,
     pub(crate) cron: Cron,
 }
 
@@ -66,7 +66,7 @@ impl Builder {
     }
 
     #[must_use]
-    pub fn retry(self, retry: bool) -> Self {
+    pub fn retry(self, retry: JsonValue) -> Self {
         Self {
             retry: Some(retry),
             ..self
@@ -100,7 +100,7 @@ impl Builder {
             ..Default::default()
         };
 
-        pj.retry = self.retry;
+        pj.retry = self.retry.clone();
         pj.queue = self.queue.clone();
         pj.args = self.args.clone().map(|a| a.to_string());
 
@@ -117,7 +117,7 @@ pub struct PeriodicJob {
     pub(crate) cron: String,
     pub(crate) queue: Option<String>,
     pub(crate) args: Option<String>,
-    retry: Option<bool>,
+    retry: Option<JsonValue>,
 
     #[serde(skip)]
     cron_schedule: Option<Cron>,
@@ -191,7 +191,7 @@ impl PeriodicJob {
             jid: new_jid(),
             created_at: chrono::Utc::now().timestamp() as f64,
             enqueued_at: None,
-            retry: self.retry.unwrap_or(false),
+            retry: self.retry.clone().unwrap_or(JsonValue::Bool(false)),
             args,
 
             // Make default eventually...

--- a/src/periodic.rs
+++ b/src/periodic.rs
@@ -1,5 +1,5 @@
 use super::Result;
-use crate::{new_jid, Error, Job, Processor, RedisConnection, RedisPool, Worker};
+use crate::{new_jid, Error, Job, Processor, RedisConnection, RedisPool, RetryOpts, Worker};
 pub use cron_clock::{Schedule as Cron, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
@@ -19,7 +19,7 @@ pub struct Builder {
     pub(crate) name: Option<String>,
     pub(crate) queue: Option<String>,
     pub(crate) args: Option<JsonValue>,
-    pub(crate) retry: Option<JsonValue>,
+    pub(crate) retry: Option<RetryOpts>,
     pub(crate) cron: Cron,
 }
 
@@ -40,6 +40,18 @@ impl Builder {
             ..self
         }
     }
+
+    #[must_use]
+    pub fn retry<RO>(self, retry: RO) -> Builder
+    where
+        RO: Into<RetryOpts>,
+    {
+        Self {
+            retry: Some(retry.into()),
+            ..self
+        }
+    }
+
     pub fn queue<S: Into<String>>(self, queue: S) -> Builder {
         Builder {
             queue: Some(queue.into()),
@@ -63,14 +75,6 @@ impl Builder {
             args: Some(args),
             ..self
         })
-    }
-
-    #[must_use]
-    pub fn retry(self, retry: JsonValue) -> Self {
-        Self {
-            retry: Some(retry),
-            ..self
-        }
     }
 
     pub async fn register<W, Args>(self, processor: &mut Processor, worker: W) -> Result<()>
@@ -117,7 +121,7 @@ pub struct PeriodicJob {
     pub(crate) cron: String,
     pub(crate) queue: Option<String>,
     pub(crate) args: Option<String>,
-    retry: Option<JsonValue>,
+    retry: Option<RetryOpts>,
 
     #[serde(skip)]
     cron_schedule: Option<Cron>,
@@ -191,7 +195,7 @@ impl PeriodicJob {
             jid: new_jid(),
             created_at: chrono::Utc::now().timestamp() as f64,
             enqueued_at: None,
-            retry: self.retry.clone().unwrap_or(JsonValue::Bool(false)),
+            retry: self.retry.clone().unwrap_or(RetryOpts::Never),
             args,
 
             // Make default eventually...

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -98,7 +98,7 @@ impl StatsPublisher {
     pub async fn publish_stats(&self, redis: RedisPool) -> Result<(), Box<dyn std::error::Error>> {
         let stats = self.create_process_stats().await?;
         let mut conn = redis.get().await?;
-        conn.cmd_with_key("HSET", self.identity.clone())
+        let _ : () = conn.cmd_with_key("HSET", self.identity.clone())
             .arg("rss")
             .arg(stats.rss)
             .arg("rtt_us")

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -98,7 +98,7 @@ impl StatsPublisher {
     pub async fn publish_stats(&self, redis: RedisPool) -> Result<(), Box<dyn std::error::Error>> {
         let stats = self.create_process_stats().await?;
         let mut conn = redis.get().await?;
-        let _ : () = conn.cmd_with_key("HSET", self.identity.clone())
+        conn.cmd_with_key("HSET", self.identity.clone())
             .arg("rss")
             .arg(stats.rss)
             .arg("rtt_us")


### PR DESCRIPTION
According to the sidekiq docs, `sidekiq_options` `retry` param can be either boolean or a number.

Change the param of the retry argument to be a JsonValue for now, as it's a convenient wrapper over different basic types