### PR TITLE
Optionally disable periodic scheduled and retry jobs

### DIFF
--- a/src/processor.rs
+++ b/src/processor.rs
@@ -41,6 +41,9 @@ pub struct ProcessorConfig {
     /// If your workload is largely IO-bound (e.g. reading from a DB, making web requests and
     /// waiting for responses, etc), this can probably be quite a bit higher than your CPU count.
     pub num_workers: usize,
+    pub enqueue_periodic_jobs: bool,
+    pub enqueue_retry_jobs: bool,
+    pub enqueue_scheduled_jobs: bool,
     // Disallow consumers from directly creating a ProcessorConfig object.
     _private: (),
 }
@@ -51,12 +54,33 @@ impl ProcessorConfig {
         self.num_workers = num_workers;
         self
     }
+
+    #[must_use]
+    pub fn enqueue_periodic_jobs(mut self, enqueue_periodic_jobs: bool) -> Self {
+        self.enqueue_periodic_jobs = enqueue_periodic_jobs;
+        self
+    }
+
+    #[must_use]
+    pub fn enqueue_retry_jobs(mut self, enqueue_retry_jobs: bool) -> Self {
+        self.enqueue_retry_jobs = enqueue_retry_jobs;
+        self
+    }
+
+    #[must_use]
+    pub fn enqueue_scheduled_jobs(mut self, enqueue_scheduled_jobs: bool) -> Self {
+        self.enqueue_scheduled_jobs = enqueue_scheduled_jobs;
+        self
+    }
 }
 
 impl Default for ProcessorConfig {
     fn default() -> Self {
         Self {
             num_workers: num_cpus::get(),
+            enqueue_periodic_jobs: true,
+            enqueue_retry_jobs: true,
+            enqueue_scheduled_jobs: true,
             _private: Default::default(),
         }
     }
@@ -260,56 +284,66 @@ impl Processor {
             }
         });
 
-        // Start retry and scheduled routines.
-        join_set.spawn({
-            let redis = self.redis.clone();
-            let cancellation_token = self.cancellation_token.clone();
-            async move {
-                let sched = Scheduled::new(redis);
-                let sorted_sets = vec!["retry".to_string(), "schedule".to_string()];
+        if self.config.enqueue_retry_jobs || self.config.enqueue_scheduled_jobs {
+            // Start retry and scheduled routines.
+            join_set.spawn({
+                let redis = self.redis.clone();
+                let cancellation_token = self.cancellation_token.clone();
+                async move {
+                    let sched = Scheduled::new(redis);
+                    let mut sorted_sets = vec![];
+                    if self.config.enqueue_retry_jobs {
+                        sorted_sets.push("retry".to_string());
+                    }
+                    if self.config.enqueue_scheduled_jobs {
+                        sorted_sets.push("schedule".to_string());
+                    }
 
-                loop {
-                    // TODO: Use process count to meet a 5 second avg.
-                    select! {
-                        _ = tokio::time::sleep(std::time::Duration::from_secs(5)) => {}
-                        _ = cancellation_token.cancelled() => {
-                            break;
+                    loop {
+                        // TODO: Use process count to meet a 5 second avg.
+                        select! {
+                            _ = tokio::time::sleep(std::time::Duration::from_secs(5)) => {}
+                            _ = cancellation_token.cancelled() => {
+                                break;
+                            }
+                        }
+
+                        if let Err(err) = sched.enqueue_jobs(chrono::Utc::now(), &sorted_sets).await {
+                            error!("Error in scheduled poller routine: {:?}", err);
                         }
                     }
 
-                    if let Err(err) = sched.enqueue_jobs(chrono::Utc::now(), &sorted_sets).await {
-                        error!("Error in scheduled poller routine: {:?}", err);
-                    }
+                    debug!("Broke out of loop for retry and scheduled");
                 }
+            });
+        }
 
-                debug!("Broke out of loop for retry and scheduled");
-            }
-        });
+        if self.config.enqueue_periodic_jobs {
+            // Watch for periodic jobs and enqueue jobs.
+            join_set.spawn({
+                let redis = self.redis.clone();
+                let cancellation_token = self.cancellation_token.clone();
+                async move {
+                    let sched = Scheduled::new(redis);
 
-        // Watch for periodic jobs and enqueue jobs.
-        join_set.spawn({
-            let redis = self.redis.clone();
-            let cancellation_token = self.cancellation_token.clone();
-            async move {
-                let sched = Scheduled::new(redis);
+                    loop {
+                        // TODO: Use process count to meet a 30 second avg.
+                        select! {
+                            _ = tokio::time::sleep(std::time::Duration::from_secs(30)) => {}
+                            _ = cancellation_token.cancelled() => {
+                                break;
+                            }
+                        }
 
-                loop {
-                    // TODO: Use process count to meet a 30 second avg.
-                    select! {
-                        _ = tokio::time::sleep(std::time::Duration::from_secs(30)) => {}
-                        _ = cancellation_token.cancelled() => {
-                            break;
+                        if let Err(err) = sched.enqueue_periodic_jobs(chrono::Utc::now()).await {
+                            error!("Error in periodic job poller routine: {}", err);
                         }
                     }
 
-                    if let Err(err) = sched.enqueue_periodic_jobs(chrono::Utc::now()).await {
-                        error!("Error in periodic job poller routine: {}", err);
-                    }
+                    debug!("Broke out of loop for periodic");
                 }
-
-                debug!("Broke out of loop for periodic");
-            }
-        });
+            });
+        }
 
         while let Some(result) = join_set.join_next().await {
             if let Err(err) = result {

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -264,7 +264,7 @@ impl Processor {
                     "UNKNOWN_HOSTNAME".to_string()
                 };
 
-                let stats_publisher = StatsPublisher::new(hostname, queues, busy_jobs);
+                let stats_publisher = StatsPublisher::new(hostname, queues, busy_jobs, self.config.num_workers);
 
                 loop {
                     // TODO: Use process count to meet a 5 second avg.

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -58,6 +58,7 @@ pub struct StatsPublisher {
     queues: Vec<String>,
     started_at: chrono::DateTime<chrono::Utc>,
     busy_jobs: Counter,
+    num_workers: usize,
 }
 
 fn generate_identity(hostname: &String) -> String {
@@ -71,7 +72,7 @@ fn generate_identity(hostname: &String) -> String {
 
 impl StatsPublisher {
     #[must_use]
-    pub fn new(hostname: String, queues: Vec<String>, busy_jobs: Counter) -> Self {
+    pub fn new(hostname: String, queues: Vec<String>, busy_jobs: Counter, num_workers: usize) -> Self {
         let identity = generate_identity(&hostname);
         let started_at = chrono::Utc::now();
 
@@ -81,6 +82,7 @@ impl StatsPublisher {
             queues,
             started_at,
             busy_jobs,
+            num_workers
         }
     }
 
@@ -143,7 +145,7 @@ impl StatsPublisher {
 
             beat: chrono::Utc::now(),
             info: ProcessInfo {
-                concurrency: num_cpus::get(),
+                concurrency: self.num_workers,
                 hostname: self.hostname.clone(),
                 identity: self.identity.clone(),
                 queues: self.queues.clone(),


### PR DESCRIPTION
We're using sidekiq-rs along with ruby sidekiq, and we'd want to avoid having sidekiq-rs enque periodic/retry/scheduled jobs

There is an issue `enqueue_jobs` code, that will cause duplicated jobs being scheduled:
If you run multiple copies of sidekiq-rs, I believe there's a race condition:

We first fetch jobs:
https://github.com/film42/sidekiq-rs/blob/c1822b742083abbb6bcde1d7f1f15e95c486f599/src/scheduled.rs#L23-L25

And only then we remove them:
https://github.com/film42/sidekiq-rs/blob/c1822b742083abbb6bcde1d7f1f15e95c486f599/src/scheduled.rs#L30

Fetching and removing is not atomic. Ruby's sidekiq does it differently: 
https://github.com/sidekiq/sidekiq/blob/60473481cd86b7363097dbb305ff6b0f8d7cac97/lib/sidekiq/scheduled.rb#L13-L20

```ruby
      LUA_ZPOPBYSCORE = <<~LUA
        local key, now = KEYS[1], ARGV[1]
        local jobs = redis.call("zrange", key, "-inf", now, "byscore", "limit", 0, 1)
        if jobs[1] then
          redis.call("zrem", key, jobs[1])
          return jobs[1]
        end
      LUA
```

They run a server-side LUA script which reads and removes jobs at the same time, which should prevent data races

For now, we rely on ruby sidekiq to do perform jobs scheduling, and disable this feature in rust sidekiq consumer side.