### PR TITLE
Only enqueue a sched job if the worker removed it

### DIFF
--- a/src/periodic.rs
+++ b/src/periodic.rs
@@ -104,8 +104,8 @@ impl Builder {
             ..Default::default()
         };
 
-        pj.retry = self.retry.clone();
-        pj.queue = self.queue.clone();
+        pj.retry.clone_from(&self.retry);
+        pj.queue.clone_from(&self.queue);
         pj.args = self.args.clone().map(|a| a.to_string());
 
         pj.hydrate_attributes()?;

--- a/src/redis.rs
+++ b/src/redis.rs
@@ -237,7 +237,7 @@ impl RedisConnection {
             .await
     }
 
-    pub async fn zrem<V>(&mut self, key: String, value: V) -> Result<bool, RedisError>
+    pub async fn zrem<V>(&mut self, key: String, value: V) -> Result<usize, RedisError>
     where
         V: ToRedisArgs + Send + Sync,
     {

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -111,7 +111,7 @@ impl StatsPublisher {
             .arg(stats.beat.timestamp())
             .arg("info")
             .arg(serde_json::to_string(&stats.info)?)
-            .query_async(conn.unnamespaced_borrow_mut())
+            .query_async::<_, ()>(conn.unnamespaced_borrow_mut())
             .await?;
 
         conn.expire(self.identity.clone(), 30).await?;


### PR DESCRIPTION
It was reported in https://github.com/film42/sidekiq-rs/pull/50 that we have a race-condition with this scheduled enqueuer code. I think the issue was that I was _assuming_ that redis would coerce a 0 to false and a 1 to true, but  I don't think that's really the case. (Still need to double check that).

Better yet, we should add a new test to prove this.

NOTE: I also updated the `n` reported by this method to only count the `n` if it actually enqueued a job.

NOTE 2: I think it's best if we bring the enqueue batch size down from 100 to 10.