### PR TITLE
Have stats use num_workers as concurrency metric, not cpu cores

### DIFF
--- a/src/processor.rs
+++ b/src/processor.rs
@@ -240,7 +240,8 @@ impl Processor {
                     "UNKNOWN_HOSTNAME".to_string()
                 };
 
-                let stats_publisher = StatsPublisher::new(hostname, queues, busy_jobs);
+                let stats_publisher =
+                    StatsPublisher::new(hostname, queues, busy_jobs, self.config.num_workers);
 
                 loop {
                     // TODO: Use process count to meet a 5 second avg.

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -58,6 +58,7 @@ pub struct StatsPublisher {
     queues: Vec<String>,
     started_at: chrono::DateTime<chrono::Utc>,
     busy_jobs: Counter,
+    concurrency: usize,
 }
 
 fn generate_identity(hostname: &String) -> String {
@@ -71,7 +72,12 @@ fn generate_identity(hostname: &String) -> String {
 
 impl StatsPublisher {
     #[must_use]
-    pub fn new(hostname: String, queues: Vec<String>, busy_jobs: Counter) -> Self {
+    pub fn new(
+        hostname: String,
+        queues: Vec<String>,
+        busy_jobs: Counter,
+        concurrency: usize,
+    ) -> Self {
         let identity = generate_identity(&hostname);
         let started_at = chrono::Utc::now();
 
@@ -81,6 +87,7 @@ impl StatsPublisher {
             queues,
             started_at,
             busy_jobs,
+            concurrency,
         }
     }
 
@@ -143,7 +150,7 @@ impl StatsPublisher {
 
             beat: chrono::Utc::now(),
             info: ProcessInfo {
-                concurrency: num_cpus::get(),
+                concurrency: self.concurrency,
                 hostname: self.hostname.clone(),
                 identity: self.identity.clone(),
                 queues: self.queues.clone(),


### PR DESCRIPTION
Thanks to @Antti for finding this bug and reporting it via https://github.com/film42/sidekiq-rs/pull/50