### PR TITLE
feat: Enable spawning workers dedicated to a specific queue

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ pub use crate::redis::{
 };
 pub use ::redis as redis_rs;
 pub use middleware::{ChainIter, ServerMiddleware};
-pub use processor::{Processor, ProcessorConfig, WorkFetcher};
+pub use processor::{Processor, ProcessorConfig, QueueConfig, WorkFetcher};
 pub use scheduled::Scheduled;
 pub use stats::{Counter, StatsPublisher};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -456,7 +456,7 @@ impl<'de> Deserialize<'de> for RetryOpts {
     {
         struct RetryOptsVisitor;
 
-        impl<'de> Visitor<'de> for RetryOptsVisitor {
+        impl Visitor<'_> for RetryOptsVisitor {
             type Value = RetryOpts;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {


### PR DESCRIPTION
In a large application, it's possible for there to be a lot of queues, each of which with many items. In addition, some queues may have a lot of items, while others may only rarely have any items. These two factors can lead to starvation of the rarely used queues if they get blocked behind a large number of items in other more heavily used queues.

Add support for spawing workers that are dedicated to a specific queue. This way, users can specify dedicated workers for their heavily used queues, and the rarely used queues can continue using a shared set of workers.