### PR TITLE
feat: Add queue fetch balance strategy

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ pub use crate::redis::{
 };
 pub use ::redis as redis_rs;
 pub use middleware::{ChainIter, ServerMiddleware};
-pub use processor::{Processor, ProcessorConfig, QueueConfig, WorkFetcher};
+pub use processor::{BalanceStrategy, Processor, ProcessorConfig, QueueConfig, WorkFetcher};
 pub use scheduled::Scheduled;
 pub use stats::{Counter, StatsPublisher};
 

--- a/tests/process_async_test.rs
+++ b/tests/process_async_test.rs
@@ -3,8 +3,8 @@ mod test {
     use async_trait::async_trait;
     use bb8::Pool;
     use sidekiq::{
-        Processor, ProcessorConfig, QueueConfig, RedisConnectionManager, RedisPool, Result,
-        WorkFetcher, Worker,
+        BalanceStrategy, Processor, ProcessorConfig, QueueConfig, RedisConnectionManager,
+        RedisPool, Result, WorkFetcher, Worker,
     };
     use std::sync::{Arc, Mutex};
 
@@ -34,6 +34,7 @@ mod test {
         let p = Processor::new(redis.clone(), vec![queue]).with_config(
             ProcessorConfig::default()
                 .num_workers(1)
+                .balance_strategy(BalanceStrategy::RoundRobin)
                 .queue_config(
                     "dedicated queue 1".to_string(),
                     QueueConfig::default().num_workers(10),


### PR DESCRIPTION
The Redis API used to fetch jobs
([brpop](https://redis.io/docs/latest/commands/brpop/)) checks queues for jobs in the order the queues are provided. This means that if the first queue in the list provided to `Processor::new` always has an item, the other queues will never have their jobs run.

Add a `BalanceStrategy` to allow ensuring that no queue is starved indefinitely. The initial (and default) algorithm implemented is a basic round robin algorithm. Before each fetch from Redis, the `Processor#queues` list is rotated by 1, ensuring that every queue has a chance to have its jobs run.