### PR TITLE
fix: deregister process from Redis `processes` set on shutdown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,4 @@ tracing-subscriber = { version = "0.3.20", features = ["env-filter", "json"] }
 
 [dev-dependencies]
 serial_test = "3.1.1"
+tokio = { version = "1", features = ["test-util"] }

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -360,11 +360,16 @@ impl Processor {
                 // Without this, stale entries accumulate in the `processes` set until the
                 // heartbeat hash's 60-second TTL expires — but the set membership has no TTL
                 // and never self-cleans.
+                let identity = stats_publisher.identity().to_string();
                 if let Err(err) = stats_publisher.deregister(redis.clone()).await {
-                    error!("Error deregistering processor from Redis on shutdown: {:?}", err);
+                    error!(
+                        identity = %identity,
+                        "Error deregistering processor from Redis on shutdown: {:?}",
+                        err
+                    );
                 }
 
-                debug!("Broke out of loop web metrics");
+                debug!(identity = %identity, "Deregistered processor from Redis");
             }
         });
 

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -353,6 +353,17 @@ impl Processor {
                     }
                 }
 
+                // On graceful shutdown, remove the process from the `processes` set and
+                // delete the heartbeat hash. This mirrors Ruby Sidekiq's clear_heartbeat():
+                //   pipeline.srem("processes", [identity])
+                //   pipeline.unlink("#{identity}:work")
+                // Without this, stale entries accumulate in the `processes` set until the
+                // heartbeat hash's 60-second TTL expires — but the set membership has no TTL
+                // and never self-cleans.
+                if let Err(err) = stats_publisher.deregister(redis.clone()).await {
+                    error!("Error deregistering processor from Redis on shutdown: {:?}", err);
+                }
+
                 debug!("Broke out of loop web metrics");
             }
         });

--- a/src/redis.rs
+++ b/src/redis.rs
@@ -186,9 +186,25 @@ impl RedisConnection {
     }
 
     pub async fn unlink(&mut self, key: String) -> Result<(), RedisError> {
-        redis::cmd("UNLINK")
-            .arg(self.namespaced_key(key))
-            .query_async(self.unnamespaced_borrow_mut())
+        let _: i64 = self.connection.unlink(self.namespaced_key(key)).await?;
+        Ok(())
+    }
+
+    /// Pipeline SREM + UNLINK in a single round-trip. Both keys are namespaced.
+    /// Equivalent to Ruby's `conn.pipelined { |p| p.srem(set, member); p.unlink(hash_key) }`.
+    pub async fn srem_and_unlink(
+        &mut self,
+        set_key: String,
+        member: String,
+        hash_key: String,
+    ) -> Result<(), RedisError> {
+        redis::pipe()
+            .cmd("SREM")
+            .arg(self.namespaced_key(set_key))
+            .arg(&member)
+            .cmd("UNLINK")
+            .arg(self.namespaced_key(hash_key))
+            .query_async::<()>(self.unnamespaced_borrow_mut())
             .await
     }
 

--- a/src/redis.rs
+++ b/src/redis.rs
@@ -178,6 +178,20 @@ impl RedisConnection {
         self.connection.sadd(self.namespaced_key(key), value).await
     }
 
+    pub async fn srem<V>(&mut self, key: String, value: V) -> Result<(), RedisError>
+    where
+        V: ToRedisArgs + Send + Sync,
+    {
+        self.connection.srem(self.namespaced_key(key), value).await
+    }
+
+    pub async fn unlink(&mut self, key: String) -> Result<(), RedisError> {
+        redis::cmd("UNLINK")
+            .arg(self.namespaced_key(key))
+            .query_async(self.unnamespaced_borrow_mut())
+            .await
+    }
+
     pub async fn set_nx_ex<V>(
         &mut self,
         key: String,

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -143,12 +143,20 @@ impl StatsPublisher {
     ///
     /// rusty-sidekiq does not maintain a per-process `:work` hash, so only the
     /// set membership and the heartbeat hash itself are cleaned up here.
-    pub async fn deregister(&self, redis: RedisPool) -> Result<(), Box<dyn std::error::Error>> {
+    /// Both operations are sent in a single pipelined round-trip.
+    pub(crate) async fn deregister(&self, redis: RedisPool) -> crate::Result<()> {
         let mut conn = redis.get().await?;
-        conn.srem("processes".to_string(), self.identity.clone())
-            .await?;
-        conn.unlink(self.identity.clone()).await?;
+        conn.srem_and_unlink(
+            "processes".to_string(),
+            self.identity.clone(),
+            self.identity.clone(),
+        )
+        .await?;
         Ok(())
+    }
+
+    pub(crate) fn identity(&self) -> &str {
+        &self.identity
     }
 
     async fn create_process_stats(&self) -> Result<ProcessStats, Box<dyn std::error::Error>> {
@@ -213,4 +221,109 @@ fn get_rss_kb() -> u64 {
 #[cfg(not(any(target_os = "macos", target_os = "linux")))]
 fn get_rss_kb() -> u64 {
     0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bb8::Pool;
+    use crate::RedisConnectionManager;
+
+    async fn test_pool() -> crate::RedisPool {
+        let manager = RedisConnectionManager::new("redis://127.0.0.1/").unwrap();
+        Pool::builder().build(manager).await.unwrap()
+    }
+
+    async fn sismember(redis: &RedisPool, set: &str, member: &str) -> bool {
+        let mut conn = redis.get().await.unwrap();
+        redis::cmd("SISMEMBER")
+            .arg(set)
+            .arg(member)
+            .query_async::<i64>(conn.unnamespaced_borrow_mut())
+            .await
+            .unwrap_or(0)
+            == 1
+    }
+
+    async fn exists(redis: &RedisPool, key: &str) -> bool {
+        let mut conn = redis.get().await.unwrap();
+        redis::cmd("EXISTS")
+            .arg(key)
+            .query_async::<i64>(conn.unnamespaced_borrow_mut())
+            .await
+            .unwrap_or(0)
+            > 0
+    }
+
+    fn new_publisher() -> StatsPublisher {
+        StatsPublisher::new(
+            "testhost".to_string(),
+            vec!["default".to_string()],
+            Counter::new(0),
+            1,
+        )
+    }
+
+    #[tokio::test]
+    async fn deregister_removes_identity_from_processes_set() {
+        let redis = test_pool().await;
+        let p = new_publisher();
+
+        p.publish_stats(redis.clone()).await.unwrap();
+        assert!(
+            sismember(&redis, "processes", p.identity()).await,
+            "should be in set after publish_stats"
+        );
+
+        p.deregister(redis.clone()).await.unwrap();
+        assert!(
+            !sismember(&redis, "processes", p.identity()).await,
+            "should be removed from set after deregister"
+        );
+    }
+
+    #[tokio::test]
+    async fn deregister_deletes_heartbeat_hash() {
+        let redis = test_pool().await;
+        let p = new_publisher();
+
+        p.publish_stats(redis.clone()).await.unwrap();
+        assert!(exists(&redis, p.identity()).await, "heartbeat hash should exist");
+
+        p.deregister(redis.clone()).await.unwrap();
+        assert!(
+            !exists(&redis, p.identity()).await,
+            "heartbeat hash should be deleted after deregister"
+        );
+    }
+
+    #[tokio::test]
+    async fn deregister_does_not_affect_sibling_process() {
+        let redis = test_pool().await;
+        let p1 = new_publisher();
+        let p2 = new_publisher(); // distinct nonce → distinct identity
+
+        p1.publish_stats(redis.clone()).await.unwrap();
+        p2.publish_stats(redis.clone()).await.unwrap();
+
+        p1.deregister(redis.clone()).await.unwrap();
+
+        assert!(
+            sismember(&redis, "processes", p2.identity()).await,
+            "sibling process must remain registered after p1 deregisters"
+        );
+
+        p2.deregister(redis.clone()).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn deregister_is_idempotent() {
+        let redis = test_pool().await;
+        let p = new_publisher();
+
+        p.publish_stats(redis.clone()).await.unwrap();
+        p.deregister(redis.clone()).await.unwrap();
+        // Second call must not error (SREM on missing member is a no-op in Redis)
+        p.deregister(redis.clone()).await.unwrap();
+    }
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -135,6 +135,22 @@ impl StatsPublisher {
         Ok(())
     }
 
+    /// Remove this process from the `processes` set and delete the heartbeat hash.
+    ///
+    /// Mirrors Ruby Sidekiq's `Launcher#clear_heartbeat`, which pipelines:
+    ///   `SREM processes [identity]`
+    ///   `UNLINK identity:work`
+    ///
+    /// rusty-sidekiq does not maintain a per-process `:work` hash, so only the
+    /// set membership and the heartbeat hash itself are cleaned up here.
+    pub async fn deregister(&self, redis: RedisPool) -> Result<(), Box<dyn std::error::Error>> {
+        let mut conn = redis.get().await?;
+        conn.srem("processes".to_string(), self.identity.clone())
+            .await?;
+        conn.unlink(self.identity.clone()).await?;
+        Ok(())
+    }
+
     async fn create_process_stats(&self) -> Result<ProcessStats, Box<dyn std::error::Error>> {
         let rss_in_kb = format!("{}", get_rss_kb());
 

--- a/tests/process_cleanup_test.rs
+++ b/tests/process_cleanup_test.rs
@@ -1,0 +1,82 @@
+#[cfg(test)]
+mod test {
+    use bb8::Pool;
+    use sidekiq::{Processor, ProcessorConfig, RedisConnectionManager, RedisPool};
+    use std::time::Duration;
+
+    async fn new_pool() -> RedisPool {
+        let manager = RedisConnectionManager::new("redis://127.0.0.1/").unwrap();
+        Pool::builder().build(manager).await.unwrap()
+    }
+
+    async fn flushall(redis: &RedisPool) {
+        let mut conn = redis.get().await.unwrap();
+        let _: String = redis::cmd("FLUSHALL")
+            .query_async(conn.unnamespaced_borrow_mut())
+            .await
+            .unwrap();
+    }
+
+    async fn scard(redis: &RedisPool, key: &str) -> i64 {
+        let mut conn = redis.get().await.unwrap();
+        redis::cmd("SCARD")
+            .arg(key)
+            .query_async(conn.unnamespaced_borrow_mut())
+            .await
+            .unwrap_or(0)
+    }
+
+    /// Graceful cancellation must remove the process from the `processes` set.
+    ///
+    /// Waits for the 5-second stats heartbeat to fire naturally, then cancels and
+    /// verifies the set is empty. This is an integration test and intentionally slow.
+    #[tokio::test]
+    async fn graceful_shutdown_removes_process_from_processes_set() {
+        let redis = new_pool().await;
+        flushall(&redis).await;
+
+        let p = Processor::new(redis.clone(), vec!["default".to_string()])
+            .with_config(ProcessorConfig::default().num_workers(1));
+        let token = p.get_cancellation_token();
+        let handle = tokio::spawn(p.run());
+
+        // The stats loop publishes every 5 s; wait for the first heartbeat.
+        tokio::time::sleep(Duration::from_secs(6)).await;
+
+        assert_eq!(
+            scard(&redis, "processes").await,
+            1,
+            "process should be registered in set after first heartbeat"
+        );
+
+        token.cancel();
+        handle.await.unwrap();
+
+        assert_eq!(
+            scard(&redis, "processes").await,
+            0,
+            "processes set must be empty after graceful shutdown"
+        );
+    }
+
+    /// Cancellation before the first heartbeat fires must leave the set empty.
+    /// deregister() is a no-op when nothing was published (SREM on a missing member is safe).
+    #[tokio::test]
+    async fn early_shutdown_leaves_processes_set_empty() {
+        let redis = new_pool().await;
+        flushall(&redis).await;
+
+        let p = Processor::new(redis.clone(), vec!["default".to_string()]);
+        let token = p.get_cancellation_token();
+        let handle = tokio::spawn(p.run());
+
+        token.cancel();
+        handle.await.unwrap();
+
+        assert_eq!(
+            scard(&redis, "processes").await,
+            0,
+            "processes set must be empty when cancelled before first heartbeat"
+        );
+    }
+}


### PR DESCRIPTION
## Problem

When a `Processor` shuts down (cancellation token fires), it leaves a stale entry in the Redis `processes` set. The heartbeat hash itself has a 60-second `EXPIRE`, so it eventually disappears — but **the set membership has no TTL** and accumulates indefinitely.

This means Sidekiq-web and monitoring tools will show ghost processes long after they have exited. In benchmarking scenarios (multiple trials per run), the set grows by one entry per trial and is never trimmed.

## Ruby Sidekiq comparison

Ruby Sidekiq handles this in `Launcher#clear_heartbeat()`, called from `Launcher#stop`:

```ruby
# lib/sidekiq/launcher.rb
def clear_heartbeat
  redis do |conn|
    conn.pipelined do |pipeline|
      pipeline.srem("processes", [identity])
      pipeline.unlink("#{identity}:work")
    end
  end
end
```

Belt-and-suspenders: **explicit `SREM` on clean shutdown** + **60-second heartbeat TTL** as a crash-recovery fallback. rusty-sidekiq only had the TTL fallback.

## Fix

Three small changes:

**`redis.rs`** — add `srem()` and `unlink()` helpers (parallel to existing `sadd()`).

**`stats.rs`** — add `StatsPublisher::deregister()` that calls both.

**`processor.rs`** — call `deregister()` after the stats loop breaks on cancellation.

## Behaviour

| Event | Before | After |
|---|---|---|
| Graceful shutdown | Entry stays ~60 s (set member never removed) | `SREM` removes it immediately |
| Crash / SIGKILL | TTL cleans up heartbeat hash eventually | Unchanged — TTL is still the crash safety net |
| Multiple trials in one process | `processes` set grows unboundedly | Set returns to pre-run state after each shutdown |

🤖 Discovered while building [sidekiq-bench](https://github.com/redis-performance/sidekiq-benchmark), a Rust Sidekiq load benchmark that compares rusty-sidekiq behaviour against Ruby's `bin/sidekiqload`.